### PR TITLE
Apply styles correctly in `RadioGroup` component

### DIFF
--- a/chartlets.js/CHANGES.md
+++ b/chartlets.js/CHANGES.md
@@ -3,6 +3,8 @@
 * Implemented dynamic resizing for Vega Charts when the side panel's 
   width changes.
   See https://github.com/xcube-dev/xcube/issues/1134
+
+* Styles are now correctly applied to `RadioGroup` component.
  
 ## Version 0.1.5 (from 2025/03/21)
   

--- a/chartlets.js/packages/lib/src/plugins/mui/RadioGroup.tsx
+++ b/chartlets.js/packages/lib/src/plugins/mui/RadioGroup.tsx
@@ -6,7 +6,7 @@ import MuiFormControlLabel from "@mui/material/FormControlLabel";
 import MuiFormLabel from "@mui/material/FormLabel";
 import { Tooltip } from "./Tooltip";
 
-import type { ComponentState, ComponentProps } from "@/index";
+import type { ComponentProps, ComponentState } from "@/index";
 
 interface RadioState extends ComponentState {
   type: "Radio";
@@ -54,13 +54,14 @@ export function RadioGroup({
   };
   return (
     <Tooltip title={tooltip}>
-      <MuiFormControl style={style} disabled={disabled}>
+      <MuiFormControl disabled={disabled}>
         <MuiFormLabel>{label}</MuiFormLabel>
         <MuiRadioGroup
           id={id}
           name={name}
           row={row}
           value={value}
+          style={style}
           onChange={handleChange}
         >
           {radioButtons &&


### PR DESCRIPTION
This PR comes from working on the following PR which requires the radio-button group to be styled:
xcube-PR: https://github.com/xcube-dev/xcube/pull/1144