### PR TITLE
Limit supported Python versions to < 3.14

### DIFF
--- a/chartlets.py/environment.yml
+++ b/chartlets.py/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   # Library Dependencies
-  - python >=3.10
+  - python >=3.10,<3.14
   # Optional Dependencies
   - altair
   # Demo Dependencies

--- a/chartlets.py/pyproject.toml
+++ b/chartlets.py/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
   "dashboard", "charts", "vega", "altair", "plots"
 ]
 license = {text = "MIT"}
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 dependencies = []
 classifiers = [
   "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This PR restricts the supported Python versions to **>=3.10,<3.14** in both `pyproject.toml` and `environment.yaml`.  

Altair 5.5 currently fails to import with Python 3.14 due to a `TypedDict` API change (`closed=` argument no longer supported). See the Error Message below for further details.

Limiting Python to 3.13 ensures a working environment.

---

Error:
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\Clara\Desktop\bc\chartlets\chartlets.py\demo\server\main.py", line 11, in <module>
    main()
    ~~~~^^
  File "C:\Users\Clara\Desktop\bc\chartlets\chartlets.py\demo\server\main.py", line 7, in main
    asyncio.run(run_app())
    ~~~~~~~~~~~^^^^^^^^^^^
  File "C:\Users\Clara\miniconda3\envs\chartlets\Lib\asyncio\runners.py", line 204, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "C:\Users\Clara\miniconda3\envs\chartlets\Lib\asyncio\runners.py", line 127, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "C:\Users\Clara\miniconda3\envs\chartlets\Lib\asyncio\base_events.py", line 719, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "C:\Users\Clara\Desktop\bc\chartlets\chartlets.py\demo\server\app.py", line 133, in run_app
    app = make_app()
  File "C:\Users\Clara\Desktop\bc\chartlets\chartlets.py\demo\server\app.py", line 123, in make_app
    ext_ctx = ExtensionContext.load(Context(), server_config.get("extensions", []))
  File "C:\Users\Clara\Desktop\bc\chartlets\chartlets.py\chartlets\extensioncontext.py", line 56, in load
    module = importlib.import_module(module_name)
  File "C:\Users\Clara\miniconda3\envs\chartlets\Lib\importlib\__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1398, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1371, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1342, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 938, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 762, in exec_module
  File "<frozen importlib._bootstrap>", line 491, in _call_with_frames_removed
  File "C:\Users\Clara\Desktop\bc\chartlets\chartlets.py\demo\my_extension\__init__.py", line 2, in <module>
    from .my_panel_1 import panel as my_panel_1
  File "C:\Users\Clara\Desktop\bc\chartlets\chartlets.py\demo\my_extension\my_panel_1.py", line 2, in <module>
    import altair as alt
  File "C:\Users\Clara\miniconda3\envs\chartlets\Lib\site-packages\altair\__init__.py", line 649, in <module>
    from altair.vegalite import *
  File "C:\Users\Clara\miniconda3\envs\chartlets\Lib\site-packages\altair\vegalite\__init__.py", line 2, in <module>
    from .v5 import *
  File "C:\Users\Clara\miniconda3\envs\chartlets\Lib\site-packages\altair\vegalite\v5\__init__.py", line 3, in <module>
    from altair.vegalite.v5 import api, compiler, schema
  File "C:\Users\Clara\miniconda3\envs\chartlets\Lib\site-packages\altair\vegalite\v5\api.py", line 19, in <module>
    from altair import theme, utils
  File "C:\Users\Clara\miniconda3\envs\chartlets\Lib\site-packages\altair\theme.py", line 9, in <module>
    from altair.vegalite.v5.schema._config import (
    ...<70 lines>...
    )
  File "C:\Users\Clara\miniconda3\envs\chartlets\Lib\site-packages\altair\vegalite\v5\schema\_config.py", line 6491, in <module>
    class StepKwds(TypedDict, closed=True, total=False):  # type: ignore[call-arg]
    ...<21 lines>...
        __extra_items__: StepFor_T
TypeError: _TypedDictMeta.__new__() got an unexpected keyword argument 'closed'
(chartlets) PS C:\Users\Clara\Desktop\bc\chartlets\chartlets.py\demo> 
```



