### PR TITLE
add components to docs

### DIFF
--- a/docs/api/components.md
+++ b/docs/api/components.md
@@ -23,7 +23,23 @@ and providers:
 
 ::: chartlets.components.IconButton
 
+::: chartlets.components.DataGrid
+
+::: chartlets.components.Dialog
+
+::: chartlets.components.Divider
+
+::: chartlets.components.RadioGroup
+
 ::: chartlets.components.Select
+
+::: chartlets.components.Slider
+
+::: chartlets.components.Switch
+
+::: chartlets.components.Table
+
+::: chartlets.components.Tabs
 
 ::: chartlets.components.Typography
 


### PR DESCRIPTION
This PR adds the following components to the Python API in the documentation:

- DataGrid
- Dialog
- Divider
- RadioGroup
- Slider
- Switch
- Tabs
- Table