### PR TITLE
Update react-vega to v8 and adapt VegaChart accordingly

### DIFF
--- a/chartlets.js/CHANGES.md
+++ b/chartlets.js/CHANGES.md
@@ -2,12 +2,18 @@
 
 * Updated dependencies
 	- `glob: ^13.0.1`
+	- `react-vega: ^8.0.0`
+	- `vega-lite: ^6.4.1`
 	- `@vitest/coverage-istanbul: ^3.2.4`
 	- `vite: ^7.1.11`
 	- `vitest: ^3.2.4`
 
 * Added icon support for `Button`, `IconButton` and `Tabs` components.
- (#124).
+ (#124)
+ 
+* Adjusted `VegaChart` component, due to `react-vega` upgrade
+  from v7 to v8. (#132)
+
 
 ## Version 0.1.7 (from 2025/12/03)
 

--- a/chartlets.js/package-lock.json
+++ b/chartlets.js/package-lock.json
@@ -1102,20 +1102,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.4.tgz",
+      "integrity": "sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.3",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -1307,13 +1307,13 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -1476,19 +1476,19 @@
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.57.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.57.3.tgz",
-      "integrity": "sha512-2+k2FNp+6zug/VmpK0wZFPQu7cKMihjHBP1iUuZs6Ep5P9uR1hD4dR5Ss7z/MiBkwVmKnUm6Pojhkz/c431SMw==",
+      "version": "7.57.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.57.6.tgz",
+      "integrity": "sha512-0rFv/D8Grzw1Mjs2+8NGUR+o4h9LVm5zKRtMeWnpdB5IMJF4TeHCL1zR5LMCIudkOvyvjbhMG5Wjs0B5nqsrRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.33.1",
+        "@microsoft/api-extractor-model": "7.33.4",
         "@microsoft/tsdoc": "~0.16.0",
-        "@microsoft/tsdoc-config": "~0.18.0",
-        "@rushstack/node-core-library": "5.20.1",
-        "@rushstack/rig-package": "0.7.1",
-        "@rushstack/terminal": "0.22.1",
-        "@rushstack/ts-command-line": "5.3.1",
+        "@microsoft/tsdoc-config": "~0.18.1",
+        "@rushstack/node-core-library": "5.20.3",
+        "@rushstack/rig-package": "0.7.2",
+        "@rushstack/terminal": "0.22.3",
+        "@rushstack/ts-command-line": "5.3.3",
         "diff": "~8.0.2",
         "lodash": "~4.17.23",
         "minimatch": "10.2.1",
@@ -1502,15 +1502,15 @@
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.33.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.1.tgz",
-      "integrity": "sha512-KX0LI6xzI0gcBOXXmr5mnnbdhsK2W93pqvJo8OgJgWvRRh+wMEp0Ccj38h1XKeJ29E1tuAZKSUOfHUQ1WA8fZg==",
+      "version": "7.33.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.4.tgz",
+      "integrity": "sha512-u1LTaNTikZAQ9uK6KG1Ms7nvNedsnODnspq/gH2dcyETWvH4hVNGNDvRAEutH66kAmxA4/necElqGNs1FggC8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "~0.16.0",
-        "@microsoft/tsdoc-config": "~0.18.0",
-        "@rushstack/node-core-library": "5.20.1"
+        "@microsoft/tsdoc-config": "~0.18.1",
+        "@rushstack/node-core-library": "5.20.3"
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/balanced-match": {
@@ -1524,9 +1524,9 @@
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1620,29 +1620,29 @@
       "license": "MIT"
     },
     "node_modules/@microsoft/tsdoc-config": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.0.tgz",
-      "integrity": "sha512-8N/vClYyfOH+l4fLkkr9+myAoR6M7akc8ntBJ4DJdWH2b09uVfr71+LTMpNyG19fNqWDg8KEDZhx5wxuqHyGjw==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
+      "integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "0.16.0",
-        "ajv": "~8.12.0",
+        "ajv": "~8.18.0",
         "jju": "~1.4.0",
         "resolve": "~1.22.2"
       }
     },
     "node_modules/@microsoft/tsdoc-config/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2524,13 +2524,13 @@
       ]
     },
     "node_modules/@rushstack/node-core-library": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.20.1.tgz",
-      "integrity": "sha512-QvxZyh+RsTJ77JpQkS9K9lJujh6lj5WyMxieT0bdACtwqxEkGB9zCuSMX5UlXRweaIgSpu1ztdHmhV07fKUpMg==",
+      "version": "5.20.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.20.3.tgz",
+      "integrity": "sha512-95JgEPq2k7tHxhF9/OJnnyHDXfC9cLhhta0An/6MlkDsX2A6dTzDrTUG18vx4vjc280V0fi0xDH9iQczpSuWsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "~8.13.0",
+        "ajv": "~8.18.0",
         "ajv-draft-04": "~1.0.0",
         "ajv-formats": "~3.0.1",
         "fs-extra": "~11.3.0",
@@ -2549,17 +2549,17 @@
       }
     },
     "node_modules/@rushstack/node-core-library/node_modules/ajv": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
-      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2640,9 +2640,9 @@
       }
     },
     "node_modules/@rushstack/rig-package": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.1.tgz",
-      "integrity": "sha512-hLwDnp4yMcAd/gcUol8NPWNctpIXzVOgMyhZ8DagnEJls9TOZd0xF//5hS+YTiX7/+4rLfBra+NoB3rtFxjDdA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.2.tgz",
+      "integrity": "sha512-9XbFWuqMYcHUso4mnETfhGVUSaADBRj6HUAAEYk50nMPn8WRICmBuCphycQGNB3duIR6EEZX3Xj3SYc2XiP+9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2651,13 +2651,13 @@
       }
     },
     "node_modules/@rushstack/terminal": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.22.1.tgz",
-      "integrity": "sha512-Mdtu0VN7v31O5Zcno8ZZH5kQHF13Ez7WN9Aio7nFJVcR36i4bkERionYrWgBDQJ0JdVPLKGecZER/xRU5IvGLw==",
+      "version": "0.22.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.22.3.tgz",
+      "integrity": "sha512-gHC9pIMrUPzAbBiI4VZMU7Q+rsCzb8hJl36lFIulIzoceKotyKL3Rd76AZ2CryCTKEg+0bnTj406HE5YY5OQvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rushstack/node-core-library": "5.20.1",
+        "@rushstack/node-core-library": "5.20.3",
         "@rushstack/problem-matcher": "0.2.1",
         "supports-color": "~8.1.1"
       },
@@ -2687,13 +2687,13 @@
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.1.tgz",
-      "integrity": "sha512-mid/JIZSJafwy3x9e4v0wVLuAqSSYYErEHV0HXPALYLSBN13YNkR5caOk0hf97lSRKrxhtvQjGaDKSEelR3sMg==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.3.tgz",
+      "integrity": "sha512-c+ltdcvC7ym+10lhwR/vWiOhsrm/bP3By2VsFcs5qTKv+6tTmxgbVrtJ5NdNjANiV5TcmOZgUN+5KYQ4llsvEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rushstack/terminal": "0.22.1",
+        "@rushstack/terminal": "0.22.3",
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
         "string-argv": "~0.3.1"
@@ -2710,9 +2710,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.13.tgz",
-      "integrity": "sha512-0l1gl/72PErwUZuavcRpRAQN9uSst+Nk++niC5IX6lmMWpXoScYx3oq/narT64/sKv/eRiPTaAjBFGDEQiWJIw==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.18.tgz",
+      "integrity": "sha512-z87aF9GphWp//fnkRsqvtY+inMVPgYW3zSlXH1kJFvRT5H/wiAn+G32qW5l3oEk63KSF1x3Ov0BfHCObAmT8RA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -2728,16 +2728,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.13",
-        "@swc/core-darwin-x64": "1.15.13",
-        "@swc/core-linux-arm-gnueabihf": "1.15.13",
-        "@swc/core-linux-arm64-gnu": "1.15.13",
-        "@swc/core-linux-arm64-musl": "1.15.13",
-        "@swc/core-linux-x64-gnu": "1.15.13",
-        "@swc/core-linux-x64-musl": "1.15.13",
-        "@swc/core-win32-arm64-msvc": "1.15.13",
-        "@swc/core-win32-ia32-msvc": "1.15.13",
-        "@swc/core-win32-x64-msvc": "1.15.13"
+        "@swc/core-darwin-arm64": "1.15.18",
+        "@swc/core-darwin-x64": "1.15.18",
+        "@swc/core-linux-arm-gnueabihf": "1.15.18",
+        "@swc/core-linux-arm64-gnu": "1.15.18",
+        "@swc/core-linux-arm64-musl": "1.15.18",
+        "@swc/core-linux-x64-gnu": "1.15.18",
+        "@swc/core-linux-x64-musl": "1.15.18",
+        "@swc/core-win32-arm64-msvc": "1.15.18",
+        "@swc/core-win32-ia32-msvc": "1.15.18",
+        "@swc/core-win32-x64-msvc": "1.15.18"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -2749,9 +2749,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.13.tgz",
-      "integrity": "sha512-ztXusRuC5NV2w+a6pDhX13CGioMLq8CjX5P4XgVJ21ocqz9t19288Do0y8LklplDtwcEhYGTNdMbkmUT7+lDTg==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.18.tgz",
+      "integrity": "sha512-+mIv7uBuSaywN3C9LNuWaX1jJJ3SKfiJuE6Lr3bd+/1Iv8oMU7oLBjYMluX1UrEPzwN2qCdY6Io0yVicABoCwQ==",
       "cpu": [
         "arm64"
       ],
@@ -2766,9 +2766,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.13.tgz",
-      "integrity": "sha512-cVifxQUKhaE7qcO/y9Mq6PEhoyvN9tSLzCnnFZ4EIabFHBuLtDDO6a+vLveOy98hAs5Qu1+bb5Nv0oa1Pihe3Q==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.18.tgz",
+      "integrity": "sha512-wZle0eaQhnzxWX5V/2kEOI6Z9vl/lTFEC6V4EWcn+5pDjhemCpQv9e/TDJ0GIoiClX8EDWRvuZwh+Z3dhL1NAg==",
       "cpu": [
         "x64"
       ],
@@ -2783,9 +2783,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.13.tgz",
-      "integrity": "sha512-t+xxEzZ48enl/wGGy7SRYd7kImWQ/+wvVFD7g5JZo234g6/QnIgZ+YdfIyjHB+ZJI3F7a2IQHS7RNjxF29UkWw==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.18.tgz",
+      "integrity": "sha512-ao61HGXVqrJFHAcPtF4/DegmwEkVCo4HApnotLU8ognfmU8x589z7+tcf3hU+qBiU1WOXV5fQX6W9Nzs6hjxDw==",
       "cpu": [
         "arm"
       ],
@@ -2800,9 +2800,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.13.tgz",
-      "integrity": "sha512-VndeGvKmTXFn6AGwjy0Kg8i7HccOCE7Jt/vmZwRxGtOfNZM1RLYRQ7MfDLo6T0h1Bq6eYzps3L5Ma4zBmjOnOg==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.18.tgz",
+      "integrity": "sha512-3xnctOBLIq3kj8PxOCgPrGjBLP/kNOddr6f5gukYt/1IZxsITQaU9TDyjeX6jG+FiCIHjCuWuffsyQDL5Ew1bg==",
       "cpu": [
         "arm64"
       ],
@@ -2817,9 +2817,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.13.tgz",
-      "integrity": "sha512-SmZ9m+XqCB35NddHCctvHFLqPZDAs5j8IgD36GoutufDJmeq2VNfgk5rQoqNqKmAK3Y7iFdEmI76QoHIWiCLyw==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.18.tgz",
+      "integrity": "sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==",
       "cpu": [
         "arm64"
       ],
@@ -2834,9 +2834,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.13.tgz",
-      "integrity": "sha512-5rij+vB9a29aNkHq72EXI2ihDZPszJb4zlApJY4aCC/q6utgqFA6CkrfTfIb+O8hxtG3zP5KERETz8mfFK6A0A==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.18.tgz",
+      "integrity": "sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==",
       "cpu": [
         "x64"
       ],
@@ -2851,9 +2851,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.13.tgz",
-      "integrity": "sha512-OlSlaOK9JplQ5qn07WiBLibkOw7iml2++ojEXhhR3rbWrNEKCD7sd8+6wSavsInyFdw4PhLA+Hy6YyDBIE23Yw==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.18.tgz",
+      "integrity": "sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==",
       "cpu": [
         "x64"
       ],
@@ -2868,9 +2868,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.13.tgz",
-      "integrity": "sha512-zwQii5YVdsfG8Ti9gIKgBKZg8qMkRZxl+OlYWUT5D93Jl4NuNBRausP20tfEkQdAPSRrMCSUZBM6FhW7izAZRg==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.18.tgz",
+      "integrity": "sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==",
       "cpu": [
         "arm64"
       ],
@@ -2885,9 +2885,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.13.tgz",
-      "integrity": "sha512-hYXvyVVntqRlYoAIDwNzkS3tL2ijP3rxyWQMNKaxcCxxkCDto/w3meOK/OB6rbQSkNw0qTUcBfU9k+T0ptYdfQ==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.18.tgz",
+      "integrity": "sha512-yVuTrZ0RccD5+PEkpcLOBAuPbYBXS6rslENvIXfvJGXSdX5QGi1ehC4BjAMl5FkKLiam4kJECUI0l7Hq7T1vwg==",
       "cpu": [
         "ia32"
       ],
@@ -2902,9 +2902,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.13.tgz",
-      "integrity": "sha512-XTzKs7c/vYCcjmcwawnQvlHHNS1naJEAzcBckMI5OJlnrcgW8UtcX9NHFYvNjGtXuKv0/9KvqL4fuahdvlNGKw==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.18.tgz",
+      "integrity": "sha512-7NRmE4hmUQNCbYU3Hn9Tz57mK9Qq4c97ZS+YlamlK6qG9Fb5g/BB3gPDe0iLlJkns/sYv2VWSkm8c3NmbEGjbg==",
       "cpu": [
         "x64"
       ],
@@ -3063,9 +3063,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
-      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "version": "20.19.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
+      "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3117,17 +3117,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
-      "integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
+      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.56.0",
-        "@typescript-eslint/type-utils": "8.56.0",
-        "@typescript-eslint/utils": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/type-utils": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.4.0"
@@ -3140,7 +3140,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.56.0",
+        "@typescript-eslint/parser": "^8.56.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -3156,17 +3156,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
-      "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
+      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.56.0",
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3182,14 +3182,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.0.tgz",
-      "integrity": "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.56.0",
-        "@typescript-eslint/types": "^8.56.0",
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3204,14 +3204,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
-      "integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0"
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3222,9 +3222,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz",
-      "integrity": "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3239,15 +3239,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz",
-      "integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
+      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0",
-        "@typescript-eslint/utils": "8.56.0",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.4.0"
       },
@@ -3264,9 +3264,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.0.tgz",
-      "integrity": "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3278,18 +3278,18 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz",
-      "integrity": "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.56.0",
-        "@typescript-eslint/tsconfig-utils": "8.56.0",
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0",
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
         "debug": "^4.4.3",
-        "minimatch": "^9.0.5",
+        "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
         "ts-api-utils": "^2.4.0"
@@ -3316,9 +3316,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3329,32 +3329,32 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.0.tgz",
-      "integrity": "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.56.0",
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0"
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3369,13 +3369,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz",
-      "integrity": "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/types": "8.56.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -3593,14 +3593,14 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.28.tgz",
-      "integrity": "sha512-kviccYxTgoE8n6OCw96BNdYlBg2GOWfBuOW4Vqwrt7mSKWKwFVvI8egdTltqRgITGPsTFYtKYfxIG8ptX2PJHQ==",
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.29.tgz",
+      "integrity": "sha512-cuzPhD8fwRHk8IGfmYaR4eEe4cAyJEL66Ove/WZL7yWNL134nqLddSLwNRIsFlnnW1kK+p8Ck3viFnC0chXCXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
-        "@vue/shared": "3.5.28",
+        "@vue/shared": "3.5.29",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
@@ -3620,14 +3620,14 @@
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.28.tgz",
-      "integrity": "sha512-/1ZepxAb159jKR1btkefDP+J2xuWL5V3WtleRmxaT+K2Aqiek/Ab/+Ebrw2pPj0sdHO8ViAyyJWfhXXOP/+LQA==",
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.29.tgz",
+      "integrity": "sha512-n0G5o7R3uBVmVxjTIYcz7ovr8sy7QObFG8OQJ3xGCDNhbG60biP/P5KnyY8NLd81OuT1WJflG7N4KWYHaeeaIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.28",
-        "@vue/shared": "3.5.28"
+        "@vue/compiler-core": "3.5.29",
+        "@vue/shared": "3.5.29"
       }
     },
     "node_modules/@vue/compiler-vue2": {
@@ -3666,37 +3666,24 @@
         }
       }
     },
-    "node_modules/@vue/language-core/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@vue/language-core/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@vue/language-core/node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3706,9 +3693,9 @@
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.28.tgz",
-      "integrity": "sha512-cfWa1fCGBxrvaHRhvV3Is0MgmrbSCxYTXCSCau2I0a1Xw1N1pHAvkWCiXPRAqjvToILvguNyEwjevUqAuBQWvQ==",
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.29.tgz",
+      "integrity": "sha512-w7SR0A5zyRByL9XUkCfdLs7t9XOHUyJ67qPGQjOou3p6GvBeBW+AVjUUmlxtZ4PIYaRvE+1LmK44O4uajlZwcg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4077,9 +4064,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001774",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
-      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "version": "1.0.30001776",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz",
+      "integrity": "sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==",
       "dev": true,
       "funding": [
         {
@@ -4228,12 +4215,12 @@
       }
     },
     "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -5353,9 +5340,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
+      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5638,9 +5625,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5651,9 +5638,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -6498,9 +6485,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7038,9 +7025,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
         {
@@ -7228,9 +7215,9 @@
       "license": "MIT"
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7341,77 +7328,18 @@
       }
     },
     "node_modules/react-vega": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/react-vega/-/react-vega-7.7.1.tgz",
-      "integrity": "sha512-Dj7n1LkfJEkY/FdwQfOZqIQ+wGUcJNwlTuWhYcuQtbBpTgvtI4wwqOvJ0QWBE19nXMU7t9HmP8sqQO5v6soOlg==",
-      "license": "Apache-2.0",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/react-vega/-/react-vega-8.0.0.tgz",
+      "integrity": "sha512-euye4Gec2ScnUK1zbSA2tzZXUwBmbba8bfbzaRVhdEJTGQfaD78bSgqrccrl9b2fKZS1TZXR0NADEHVe6nxvBg==",
       "peer": true,
       "dependencies": {
-        "@types/react": "*",
-        "fast-deep-equal": "^3.1.1",
-        "prop-types": "^15.8.1",
-        "vega-embed": "6.5.1"
+        "fast-deep-equal": "^3.1.3"
       },
       "peerDependencies": {
-        "react": "^16 || ^17 || ^18 || ^19",
-        "vega": "*",
-        "vega-lite": "*"
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19",
+        "vega-embed": "^7"
       }
-    },
-    "node_modules/react-vega/node_modules/json-stringify-pretty-compact": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
-      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==",
-      "license": "MIT"
-    },
-    "node_modules/react-vega/node_modules/vega-embed": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.5.1.tgz",
-      "integrity": "sha512-yz/L1bN3+fLOpgXVb/8sCRv4GlZpD2/ngeKJAFRiHTIRm5zK6W0KuqZZvyGaO7E4s7RuYjW1TWhRIOqh5rS5hA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "fast-json-patch": "^3.0.0-1",
-        "json-stringify-pretty-compact": "^2.0.0",
-        "semver": "^7.1.3",
-        "vega-schema-url-parser": "^1.1.0",
-        "vega-themes": "^2.8.2",
-        "vega-tooltip": "^0.22.0"
-      },
-      "peerDependencies": {
-        "vega": "^5.8.0",
-        "vega-lite": "*"
-      }
-    },
-    "node_modules/react-vega/node_modules/vega-schema-url-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-1.1.0.tgz",
-      "integrity": "sha512-Tc85J2ofMZZOsxiqDM9sbvfsa+Vdo3GwNLjEEsPOsCDeYqsUHKAlc1IpbbhPLZ6jusyM9Lk0e1izF64GGklFDg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/react-vega/node_modules/vega-themes": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.15.0.tgz",
-      "integrity": "sha512-DicRAKG9z+23A+rH/3w3QjJvKnlGhSbbUXGjBvYGseZ1lvj9KQ0BXZ2NS/+MKns59LNpFNHGi9us/wMlci4TOA==",
-      "license": "BSD-3-Clause",
-      "peerDependencies": {
-        "vega": "*",
-        "vega-lite": "*"
-      }
-    },
-    "node_modules/react-vega/node_modules/vega-tooltip": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.22.1.tgz",
-      "integrity": "sha512-mPmzxwvi6+2ZgbZ/+mNC7XbSu5I6Ckon8zdgUfH9neb+vV7CKlV/FYypMdVN/9iDMFUqGzybYdqNOiSPPIxFEQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "vega-util": "^1.13.1"
-      }
-    },
-    "node_modules/react-vega/node_modules/vega-util": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
-      "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -8039,9 +7967,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8073,14 +8001,31 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/test-exclude/node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -8097,9 +8042,9 @@
       "license": "ISC"
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -9276,12 +9221,12 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -9432,12 +9377,12 @@
       }
     },
     "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -9523,10 +9468,10 @@
         "chartlets": "file:../lib",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-vega": "^7.7.1",
+        "react-vega": "^8.0.0",
         "vega": "^6.2.0",
         "vega-embed": "^7.1.0",
-        "vega-lite": "^6.4.1",
+        "vega-lite": "^6.4.2",
         "vega-themes": ">=2",
         "zustand": "^5.0.0"
       },
@@ -9594,10 +9539,10 @@
         "@mui/x-data-grid": ">=7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-vega": "^7.7.1",
+        "react-vega": "^8.0.0",
         "vega": "^6.2.0",
         "vega-embed": "^7.1.0",
-        "vega-lite": "^6.4.1",
+        "vega-lite": "^6.4.2",
         "vega-themes": ">=2"
       },
       "peerDependenciesMeta": {

--- a/chartlets.js/packages/demo/package.json
+++ b/chartlets.js/packages/demo/package.json
@@ -34,10 +34,10 @@
     "chartlets": "file:../lib",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-vega": "^7.7.1",
+    "react-vega": "^8.0.0",
     "vega": "^6.2.0",
     "vega-embed": "^7.1.0",
-    "vega-lite": "^6.4.1",
+    "vega-lite": "^6.4.2",
     "vega-themes": ">=2",
     "zustand": "^5.0.0"
   },

--- a/chartlets.js/packages/lib/package.json
+++ b/chartlets.js/packages/lib/package.json
@@ -65,10 +65,10 @@
     "@mui/x-data-grid": ">=7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-vega": "^7.7.1",
+    "react-vega": "^8.0.0",
     "vega": "^6.2.0",
     "vega-embed": "^7.1.0",
-    "vega-lite": "^6.4.1",
+    "vega-lite": "^6.4.2",
     "vega-themes": ">=2"
   },
   "peerDependenciesMeta": {

--- a/chartlets.js/packages/lib/src/plugins/vega/VegaChart.test.tsx
+++ b/chartlets.js/packages/lib/src/plugins/vega/VegaChart.test.tsx
@@ -50,7 +50,7 @@ describe("VegaChart", () => {
 });
 
 const chart: TopLevelSpec = {
-  $schema: "https://vega.github.io/schema/vega-lite/v5.20.1.json",
+  $schema: "https://vega.github.io/schema/vega-lite/v6.json",
   config: { view: { continuousWidth: 300, continuousHeight: 300 } },
   data: { name: "data-0" },
   mark: { type: "bar" },

--- a/chartlets.js/packages/lib/src/plugins/vega/VegaChart.tsx
+++ b/chartlets.js/packages/lib/src/plugins/vega/VegaChart.tsx
@@ -4,7 +4,8 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { VegaLite } from "react-vega";
+import { useRef } from "react";
+import { VegaEmbed } from "react-vega";
 import type { TopLevelSpec } from "vega-lite";
 
 import type { ComponentProps, ComponentState } from "@/index";
@@ -14,9 +15,7 @@ import { useResizeObserver } from "./hooks/useResizeObserver";
 
 interface VegaChartState extends ComponentState {
   theme?: VegaTheme | "default" | "system";
-  chart?:
-    | TopLevelSpec // This is the vega-lite specification type
-    | null;
+  chart?: TopLevelSpec | null;
 }
 
 interface VegaChartProps extends ComponentProps, VegaChartState {}
@@ -29,19 +28,25 @@ export function VegaChart({
   chart,
   onChange,
 }: VegaChartProps) {
-  const signalListeners = useSignalListeners(chart, type, id, onChange);
+  const { onEmbed } = useSignalListeners(chart, type, id, onChange);
   const vegaTheme = useVegaTheme(theme);
   const { containerSizeKey, containerCallbackRef } = useResizeObserver();
+
+  const embedDivRef = useRef<HTMLDivElement | null>(null);
+
   if (chart) {
     return (
       <div id="chart-container" ref={containerCallbackRef} style={style}>
-        <VegaLite
+        <VegaEmbed
           key={containerSizeKey}
-          theme={vegaTheme}
+          ref={embedDivRef}
           spec={chart}
+          onEmbed={onEmbed}
+          options={{
+            actions: false,
+            theme: vegaTheme,
+          }}
           style={style}
-          signalListeners={signalListeners}
-          actions={false}
         />
       </div>
     );

--- a/chartlets.js/packages/lib/src/plugins/vega/hooks/useSignalListeners.test.ts
+++ b/chartlets.js/packages/lib/src/plugins/vega/hooks/useSignalListeners.test.ts
@@ -11,7 +11,7 @@ import { useSignalListeners } from "./useSignalListeners";
 import { createChangeHandler } from "@/plugins/mui/common.test";
 
 const chart: TopLevelSpec = {
-  $schema: "https://vega.github.io/schema/vega-lite/v5.20.1.json",
+  $schema: "https://vega.github.io/schema/vega-lite/v6.json",
   config: { view: { continuousWidth: 300, continuousHeight: 300 } },
   data: { name: "data-0" },
   mark: { type: "bar" },
@@ -54,9 +54,9 @@ describe("useSignalListeners", () => {
     const { result, rerender } = renderHook(() =>
       useSignalListeners(chart, "VegaChart", "my_chart", () => {}),
     );
-    const signalHandlers1 = result.current;
+    const signalHandlers1 = result.current.signalListenerMap;
     rerender();
-    const signalHandlers2 = result.current;
+    const signalHandlers2 = result.current.signalListenerMap;
     expect(signalHandlers1).toEqual({});
     expect(signalHandlers2).toEqual({});
     expect(signalHandlers1).toBe(signalHandlers1);

--- a/chartlets.js/packages/lib/src/plugins/vega/hooks/useSignalListeners.test.ts
+++ b/chartlets.js/packages/lib/src/plugins/vega/hooks/useSignalListeners.test.ts
@@ -4,12 +4,11 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import type { TopLevelSpec } from "vega-lite";
 import { useSignalListeners } from "./useSignalListeners";
 import { createChangeHandler } from "@/plugins/mui/common.test";
-import type { Result as VegaEmbedResult } from "vega-embed";
 
 const chart: TopLevelSpec = {
   $schema: "https://vega.github.io/schema/vega-lite/v6.json",
@@ -96,99 +95,4 @@ describe("useSignalListeners", () => {
       value: [1, 2, 3],
     });
   });
-
-  it("should register signal listeners on embed", () => {
-    const { result } = renderHook(() =>
-      useSignalListeners(chartWithSelect, "VegaChart", "my_chart", () => {}),
-    );
-
-    const view = createMockView();
-
-    act(() => {
-      result.current.onEmbed({ view } as unknown as VegaEmbedResult);
-    });
-
-    // Supported signals: sel_point, sel_interval, sel_point_a
-    expect(view.addSignalListener).toHaveBeenCalledTimes(3);
-
-    const names = view.addSignalListener.mock.calls.map(([name]) => name);
-    expect(names).toEqual(
-      expect.arrayContaining(["sel_point", "sel_interval", "sel_point_a"]),
-    );
-
-    // Unsupported "wheel" should not be registered
-    expect(names).not.toContain("sel_interval_b");
-  });
-
-  it("should remove old listeners when embedding again", () => {
-    const { result } = renderHook(() =>
-      useSignalListeners(chartWithSelect, "VegaChart", "my_chart", () => {}),
-    );
-
-    const view1 = createMockView();
-    const view2 = createMockView();
-
-    act(() => {
-      result.current.onEmbed({ view: view1 } as unknown as VegaEmbedResult);
-    });
-
-    const attachedToView1 = view1.addSignalListener.mock.calls.map(
-      ([name, fn]) => ({ name, fn }),
-    );
-
-    act(() => {
-      result.current.onEmbed({ view: view2 } as unknown as VegaEmbedResult);
-    });
-
-    expect(view1.removeSignalListener).toHaveBeenCalledTimes(
-      attachedToView1.length,
-    );
-
-    for (const { name, fn } of attachedToView1) {
-      expect(view1.removeSignalListener).toHaveBeenCalledWith(name, fn);
-    }
-
-    expect(view2.addSignalListener).toHaveBeenCalledTimes(3);
-  });
-
-  it("should cleanup listeners on unmount", () => {
-    const { result, unmount } = renderHook(() =>
-      useSignalListeners(chartWithSelect, "VegaChart", "my_chart", () => {}),
-    );
-
-    const view = createMockView();
-
-    act(() => {
-      result.current.onEmbed({ view } as unknown as VegaEmbedResult);
-    });
-
-    const attached = view.addSignalListener.mock.calls.map(([name, fn]) => ({
-      name,
-      fn,
-    }));
-
-    unmount();
-
-    expect(view.removeSignalListener).toHaveBeenCalledTimes(attached.length);
-    for (const { name, fn } of attached) {
-      expect(view.removeSignalListener).toHaveBeenCalledWith(name, fn);
-    }
-  });
-
-  it("should do nothing if embed result has no view", () => {
-    const { result } = renderHook(() =>
-      useSignalListeners(chartWithSelect, "VegaChart", "my_chart", () => {}),
-    );
-
-    act(() => {
-      result.current.onEmbed({} as unknown as VegaEmbedResult);
-    });
-  });
 });
-
-function createMockView() {
-  return {
-    addSignalListener: vi.fn(),
-    removeSignalListener: vi.fn(),
-  };
-}

--- a/chartlets.js/packages/lib/src/plugins/vega/hooks/useSignalListeners.test.ts
+++ b/chartlets.js/packages/lib/src/plugins/vega/hooks/useSignalListeners.test.ts
@@ -4,11 +4,12 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import type { TopLevelSpec } from "vega-lite";
 import { useSignalListeners } from "./useSignalListeners";
 import { createChangeHandler } from "@/plugins/mui/common.test";
+import type { Result as VegaEmbedResult } from "vega-embed";
 
 const chart: TopLevelSpec = {
   $schema: "https://vega.github.io/schema/vega-lite/v6.json",
@@ -72,7 +73,7 @@ describe("useSignalListeners", () => {
     expect(signalHandlers["sel_interval"]).toBeTypeOf("function");
     expect(signalHandlers["sel_point_a"]).toBeTypeOf("function");
     // "wheel" not supported
-    expect(signalHandlers["sel_point_b"]).toBeUndefined();
+    expect(signalHandlers["sel_interval_b"]).toBeUndefined();
   });
 
   it("should call onChange", () => {
@@ -95,4 +96,99 @@ describe("useSignalListeners", () => {
       value: [1, 2, 3],
     });
   });
+
+  it("should register signal listeners on embed", () => {
+    const { result } = renderHook(() =>
+      useSignalListeners(chartWithSelect, "VegaChart", "my_chart", () => {}),
+    );
+
+    const view = createMockView();
+
+    act(() => {
+      result.current.onEmbed({ view } as unknown as VegaEmbedResult);
+    });
+
+    // Supported signals: sel_point, sel_interval, sel_point_a
+    expect(view.addSignalListener).toHaveBeenCalledTimes(3);
+
+    const names = view.addSignalListener.mock.calls.map(([name]) => name);
+    expect(names).toEqual(
+      expect.arrayContaining(["sel_point", "sel_interval", "sel_point_a"]),
+    );
+
+    // Unsupported "wheel" should not be registered
+    expect(names).not.toContain("sel_interval_b");
+  });
+
+  it("should remove old listeners when embedding again", () => {
+    const { result } = renderHook(() =>
+      useSignalListeners(chartWithSelect, "VegaChart", "my_chart", () => {}),
+    );
+
+    const view1 = createMockView();
+    const view2 = createMockView();
+
+    act(() => {
+      result.current.onEmbed({ view: view1 } as unknown as VegaEmbedResult);
+    });
+
+    const attachedToView1 = view1.addSignalListener.mock.calls.map(
+      ([name, fn]) => ({ name, fn }),
+    );
+
+    act(() => {
+      result.current.onEmbed({ view: view2 } as unknown as VegaEmbedResult);
+    });
+
+    expect(view1.removeSignalListener).toHaveBeenCalledTimes(
+      attachedToView1.length,
+    );
+
+    for (const { name, fn } of attachedToView1) {
+      expect(view1.removeSignalListener).toHaveBeenCalledWith(name, fn);
+    }
+
+    expect(view2.addSignalListener).toHaveBeenCalledTimes(3);
+  });
+
+  it("should cleanup listeners on unmount", () => {
+    const { result, unmount } = renderHook(() =>
+      useSignalListeners(chartWithSelect, "VegaChart", "my_chart", () => {}),
+    );
+
+    const view = createMockView();
+
+    act(() => {
+      result.current.onEmbed({ view } as unknown as VegaEmbedResult);
+    });
+
+    const attached = view.addSignalListener.mock.calls.map(([name, fn]) => ({
+      name,
+      fn,
+    }));
+
+    unmount();
+
+    expect(view.removeSignalListener).toHaveBeenCalledTimes(attached.length);
+    for (const { name, fn } of attached) {
+      expect(view.removeSignalListener).toHaveBeenCalledWith(name, fn);
+    }
+  });
+
+  it("should do nothing if embed result has no view", () => {
+    const { result } = renderHook(() =>
+      useSignalListeners(chartWithSelect, "VegaChart", "my_chart", () => {}),
+    );
+
+    act(() => {
+      result.current.onEmbed({} as unknown as VegaEmbedResult);
+    });
+  });
 });
+
+function createMockView() {
+  return {
+    addSignalListener: vi.fn(),
+    removeSignalListener: vi.fn(),
+  };
+}

--- a/chartlets.js/packages/lib/src/plugins/vega/hooks/useSignalListeners.test.ts
+++ b/chartlets.js/packages/lib/src/plugins/vega/hooks/useSignalListeners.test.ts
@@ -66,7 +66,7 @@ describe("useSignalListeners", () => {
     const { result } = renderHook(() =>
       useSignalListeners(chartWithSelect, "VegaChart", "my_chart", () => {}),
     );
-    const signalHandlers = result.current;
+    const signalHandlers = result.current.signalListenerMap;
     expect(signalHandlers).toBeDefined();
     expect(signalHandlers["sel_point"]).toBeTypeOf("function");
     expect(signalHandlers["sel_interval"]).toBeTypeOf("function");
@@ -80,7 +80,7 @@ describe("useSignalListeners", () => {
     const { result } = renderHook(() =>
       useSignalListeners(chartWithSelect, "VegaChart", "my_chart", onChange),
     );
-    const signalHandlers = result.current;
+    const signalHandlers = result.current.signalListenerMap;
     expect(signalHandlers).toBeDefined();
     const signalHandler = signalHandlers["sel_point_a"];
     expect(signalHandler).toBeTypeOf("function");

--- a/chartlets.js/packages/lib/src/plugins/vega/hooks/useSignalListeners.ts
+++ b/chartlets.js/packages/lib/src/plugins/vega/hooks/useSignalListeners.ts
@@ -4,7 +4,7 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useEffect, useRef } from "react";
 import type { TopLevelSpec } from "vega-lite";
 
 import { type ComponentChangeHandler } from "@/index";
@@ -37,7 +37,7 @@ export function useSignalListeners(
   type: string,
   id: string | undefined,
   onChange: ComponentChangeHandler,
-): Record<string, SignalHandler> {
+) /*: Record<string, SignalHandler>*/ {
   /*
    * Here, we create map of signals which will be then used to create the
    * map of signal-listeners because not all params are event-listeners, and we
@@ -65,7 +65,7 @@ export function useSignalListeners(
       }, signalNames);
   }, [chart]);
 
-  const handleClickSignal = useCallback(
+  const handleSignal = useCallback(
     (signalName: string, signalValue: unknown) => {
       if (id) {
         return onChange({
@@ -83,14 +83,14 @@ export function useSignalListeners(
    * Creates the map of signal listeners based on
    * the `signals` map computed above.
    */
-  return useMemo(() => {
+  const signalListenerMap = useMemo(() => {
     /*
      * Currently, we only have click events support, but if more are required,
      * they can be implemented and added in the map below.
      */
     const signalHandlers: Record<string, SignalHandler> = {
-      click: handleClickSignal,
-      drag: handleClickSignal,
+      click: handleSignal,
+      drag: handleSignal,
     };
 
     const signalListeners: Record<string, SignalHandler> = {};
@@ -104,5 +104,49 @@ export function useSignalListeners(
       }
     });
     return signalListeners;
-  }, [signalNames, handleClickSignal]);
+  }, [signalNames, handleSignal]);
+
+  // Keep cleanup in a ref so it can run on re-embed and unmount.
+  const cleanupRef = useRef<null | (() => void)>(null);
+
+  const onEmbed = useCallback(
+    (result: any | { view: any }) => {
+      cleanupRef.current?.();
+      cleanupRef.current = null;
+
+      const view = result?.view;
+      if (!view) return;
+
+      /*
+       * Keep track of the exact listener functions registered on the Vega view.
+       * Vega requires the same function reference for removal, so we store them
+       * here in order to properly clean them up on re-embed or unmount.
+       */
+      const attachedListeners: Array<{
+        name: string;
+        fn: (name: string, value: unknown) => void;
+      }> = [];
+
+      for (const [signalName, handler] of Object.entries(signalListenerMap)) {
+        const fn = (name: string, value: unknown) => handler(name, value);
+        view.addSignalListener(signalName, fn);
+        attachedListeners.push({ name: signalName, fn });
+      }
+
+      cleanupRef.current = () => {
+        for (const { name, fn } of attachedListeners)
+          view.removeSignalListener(name, fn);
+      };
+    },
+    [signalListenerMap],
+  );
+
+  useEffect(() => {
+    return () => {
+      cleanupRef.current?.();
+      cleanupRef.current = null;
+    };
+  }, []);
+
+  return { onEmbed, signalListenerMap };
 }

--- a/chartlets.js/packages/lib/src/plugins/vega/hooks/useSignalListeners.ts
+++ b/chartlets.js/packages/lib/src/plugins/vega/hooks/useSignalListeners.ts
@@ -5,6 +5,7 @@
  */
 
 import { useCallback, useMemo, useEffect, useRef } from "react";
+import type { Result as VegaEmbedResult } from "vega-embed";
 import type { TopLevelSpec } from "vega-lite";
 
 import { type ComponentChangeHandler } from "@/index";
@@ -110,7 +111,7 @@ export function useSignalListeners(
   const cleanupRef = useRef<null | (() => void)>(null);
 
   const onEmbed = useCallback(
-    (result: any | { view: any }) => {
+    (result: VegaEmbedResult) => {
       cleanupRef.current?.();
       cleanupRef.current = null;
 

--- a/chartlets.js/packages/lib/src/plugins/vega/hooks/useSignalListeners.ts
+++ b/chartlets.js/packages/lib/src/plugins/vega/hooks/useSignalListeners.ts
@@ -4,13 +4,14 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { useCallback, useMemo, useEffect, useRef } from "react";
+import { useCallback, useMemo } from "react";
 import type { Result as VegaEmbedResult } from "vega-embed";
 import type { TopLevelSpec } from "vega-lite";
 
 import { type ComponentChangeHandler } from "@/index";
 import { isString } from "@/utils/isString";
 import { isObject } from "@/utils/isObject";
+import { useVegaSignalEmbed } from "./useVegaSignalEmbed";
 
 type SignalHandler = (signalName: string, signalValue: unknown) => void;
 
@@ -112,47 +113,7 @@ export function useSignalListeners(
     return signalListeners;
   }, [signalNames, handleSignal]);
 
-  // Keep cleanup in a ref so it can run on re-embed and unmount.
-  const cleanupRef = useRef<null | (() => void)>(null);
-
-  const onEmbed = useCallback(
-    (result: VegaEmbedResult) => {
-      cleanupRef.current?.();
-      cleanupRef.current = null;
-
-      const view = result?.view;
-      if (!view) return;
-
-      /*
-       * Keep track of the exact listener functions registered on the Vega view.
-       * Vega requires the same function reference for removal, so we store them
-       * here in order to properly clean them up on re-embed or unmount.
-       */
-      const attachedListeners: Array<{
-        name: string;
-        fn: (name: string, value: unknown) => void;
-      }> = [];
-
-      for (const [signalName, handler] of Object.entries(signalListenerMap)) {
-        const fn = (name: string, value: unknown) => handler(name, value);
-        view.addSignalListener(signalName, fn);
-        attachedListeners.push({ name: signalName, fn });
-      }
-
-      cleanupRef.current = () => {
-        for (const { name, fn } of attachedListeners)
-          view.removeSignalListener(name, fn);
-      };
-    },
-    [signalListenerMap],
-  );
-
-  useEffect(() => {
-    return () => {
-      cleanupRef.current?.();
-      cleanupRef.current = null;
-    };
-  }, []);
+  const onEmbed = useVegaSignalEmbed(signalListenerMap);
 
   return { onEmbed, signalListenerMap };
 }

--- a/chartlets.js/packages/lib/src/plugins/vega/hooks/useSignalListeners.ts
+++ b/chartlets.js/packages/lib/src/plugins/vega/hooks/useSignalListeners.ts
@@ -25,6 +25,11 @@ type SelectionParameter = {
   select: "point" | "interval" | { type: "point" | "interval"; on: string };
 };
 
+type UseSignalListenersReturn = {
+  onEmbed: (result: VegaEmbedResult) => void;
+  signalListenerMap: Record<string, SignalHandler>;
+};
+
 const isSelectionParameter = (param: unknown): param is SelectionParameter =>
   isObject(param) &&
   (param.select === "point" ||
@@ -38,7 +43,7 @@ export function useSignalListeners(
   type: string,
   id: string | undefined,
   onChange: ComponentChangeHandler,
-) /*: Record<string, SignalHandler>*/ {
+): UseSignalListenersReturn {
   /*
    * Here, we create map of signals which will be then used to create the
    * map of signal-listeners because not all params are event-listeners, and we

--- a/chartlets.js/packages/lib/src/plugins/vega/hooks/useVegaSignalEmbed.test.ts
+++ b/chartlets.js/packages/lib/src/plugins/vega/hooks/useVegaSignalEmbed.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2019-2026 by Brockmann Consult Development team
+ * Permissions are hereby granted under the terms of the MIT License:
+ * https://opensource.org/licenses/MIT.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { Result as VegaEmbedResult } from "vega-embed";
+
+import { useVegaSignalEmbed } from "./useVegaSignalEmbed";
+
+type SignalHandler = (signalName: string, signalValue: unknown) => void;
+
+describe("useVegaSignalEmbed", () => {
+  it("should register signal listeners on embed", () => {
+    const signalListenerMap: Record<string, SignalHandler> = {
+      sel_point: vi.fn(),
+      sel_interval: vi.fn(),
+      sel_point_a: vi.fn(),
+    };
+
+    const { result } = renderHook(() => useVegaSignalEmbed(signalListenerMap));
+
+    const view = createMockView();
+
+    act(() => {
+      result.current({ view } as unknown as VegaEmbedResult);
+    });
+
+    expect(view.addSignalListener).toHaveBeenCalledTimes(3);
+
+    const names = view.addSignalListener.mock.calls.map(([name]) => name);
+    expect(names).toEqual(
+      expect.arrayContaining(["sel_point", "sel_interval", "sel_point_a"]),
+    );
+  });
+
+  it("should remove old listeners when embedding again", () => {
+    const signalListenerMap: Record<string, SignalHandler> = {
+      sel_point: vi.fn(),
+      sel_interval: vi.fn(),
+    };
+
+    const { result } = renderHook(() => useVegaSignalEmbed(signalListenerMap));
+
+    const view1 = createMockView();
+    const view2 = createMockView();
+
+    act(() => {
+      result.current({ view: view1 } as unknown as VegaEmbedResult);
+    });
+
+    const attachedToView1 = view1.addSignalListener.mock.calls.map(
+      ([name, fn]) => ({ name, fn }),
+    );
+
+    act(() => {
+      result.current({ view: view2 } as unknown as VegaEmbedResult);
+    });
+
+    expect(view1.removeSignalListener).toHaveBeenCalledTimes(
+      attachedToView1.length,
+    );
+
+    for (const { name, fn } of attachedToView1) {
+      expect(view1.removeSignalListener).toHaveBeenCalledWith(name, fn);
+    }
+
+    expect(view2.addSignalListener).toHaveBeenCalledTimes(2);
+  });
+
+  it("should cleanup listeners on unmount", () => {
+    const signalListenerMap: Record<string, SignalHandler> = {
+      sel_point: vi.fn(),
+      sel_interval: vi.fn(),
+    };
+
+    const { result, unmount } = renderHook(() =>
+      useVegaSignalEmbed(signalListenerMap),
+    );
+
+    const view = createMockView();
+
+    act(() => {
+      result.current({ view } as unknown as VegaEmbedResult);
+    });
+
+    const attached = view.addSignalListener.mock.calls.map(([name, fn]) => ({
+      name,
+      fn,
+    }));
+
+    unmount();
+
+    expect(view.removeSignalListener).toHaveBeenCalledTimes(attached.length);
+
+    for (const { name, fn } of attached) {
+      expect(view.removeSignalListener).toHaveBeenCalledWith(name, fn);
+    }
+  });
+
+  it("should do nothing if embed result has no view", () => {
+    const signalListenerMap: Record<string, SignalHandler> = {
+      sel_point: vi.fn(),
+    };
+
+    const { result } = renderHook(() => useVegaSignalEmbed(signalListenerMap));
+
+    act(() => {
+      result.current({} as VegaEmbedResult);
+    });
+  });
+
+  it("should register no listeners if the signal listener map is empty", () => {
+    const { result } = renderHook(() => useVegaSignalEmbed({}));
+
+    const view = createMockView();
+
+    act(() => {
+      result.current({ view } as unknown as VegaEmbedResult);
+    });
+
+    expect(view.addSignalListener).not.toHaveBeenCalled();
+    expect(view.removeSignalListener).not.toHaveBeenCalled();
+  });
+});
+
+function createMockView() {
+  return {
+    addSignalListener: vi.fn(),
+    removeSignalListener: vi.fn(),
+  };
+}

--- a/chartlets.js/packages/lib/src/plugins/vega/hooks/useVegaSignalEmbed.ts
+++ b/chartlets.js/packages/lib/src/plugins/vega/hooks/useVegaSignalEmbed.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2019-2026 by Brockmann Consult Development team
+ * Permissions are hereby granted under the terms of the MIT License:
+ * https://opensource.org/licenses/MIT.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+import type { Result as VegaEmbedResult } from "vega-embed";
+
+type SignalHandler = (signalName: string, signalValue: unknown) => void;
+
+export function useVegaSignalEmbed(
+  signalListenerMap: Record<string, SignalHandler>,
+): (result: VegaEmbedResult) => void {
+  // Keep cleanup in a ref so it can run on re-embed and unmount.
+  const cleanupRef = useRef<null | (() => void)>(null);
+
+  const onEmbed = useCallback(
+    (result: VegaEmbedResult) => {
+      cleanupRef.current?.();
+      cleanupRef.current = null;
+
+      const view = result?.view;
+      if (!view) return;
+
+      /*
+       * Keep track of the exact listener functions registered on the Vega view.
+       * Vega requires the same function reference for removal, so we store them
+       * here in order to properly clean them up on re-embed or unmount.
+       */
+      const attachedListeners: Array<{
+        name: string;
+        fn: (name: string, value: unknown) => void;
+      }> = [];
+
+      for (const [signalName, handler] of Object.entries(signalListenerMap)) {
+        const fn = (name: string, value: unknown) => handler(name, value);
+        view.addSignalListener(signalName, fn);
+        attachedListeners.push({ name: signalName, fn });
+      }
+
+      cleanupRef.current = () => {
+        for (const { name, fn } of attachedListeners) {
+          view.removeSignalListener(name, fn);
+        }
+      };
+    },
+    [signalListenerMap],
+  );
+
+  useEffect(() => {
+    return () => {
+      cleanupRef.current?.();
+      cleanupRef.current = null;
+    };
+  }, []);
+
+  return onEmbed;
+}

--- a/chartlets.js/packages/lib/vite.config.ts
+++ b/chartlets.js/packages/lib/vite.config.ts
@@ -78,6 +78,5 @@ export default defineConfig({
         return false;
       }
     },
-    exclude: ["**/vega/index.test.ts", "**/vega/VegaChart.test.tsx"],
   },
 });

--- a/chartlets.py/CHANGES.md
+++ b/chartlets.py/CHANGES.md
@@ -2,6 +2,8 @@
 
 * Added `size` and removed `variant` property from `IconButton`
   component to align with component in chartlets.js. (#124)
+  
+* Removed pinning of `altair` dependency. (#132)
 
 ## Version 0.1.7 (from 2025/12/03)
 

--- a/chartlets.py/CHANGES.md
+++ b/chartlets.py/CHANGES.md
@@ -3,7 +3,8 @@
 * Added `size` and removed `variant` property from `IconButton`
   component to align with component in chartlets.js. (#124)
   
-* Removed pinning of `altair` dependency. (#132)
+* Updated dependencies
+	- `altair>=6.0.0,<7.0.0` (#132)
 
 ## Version 0.1.7 (from 2025/12/03)
 

--- a/chartlets.py/environment.yml
+++ b/chartlets.py/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   # Library Dependencies
   - python >=3.10,<3.14
   # Optional Dependencies
-  - altair>=5.5.0,<6.0.0
+  - altair
   # Demo Dependencies
   - pandas
   - pyaml

--- a/chartlets.py/environment.yml
+++ b/chartlets.py/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   # Library Dependencies
   - python >=3.10,<3.14
   # Optional Dependencies
-  - altair
+  - altair >=6.0.0,<7.0.0
   # Demo Dependencies
   - pandas
   - pyaml

--- a/chartlets.py/pyproject.toml
+++ b/chartlets.py/pyproject.toml
@@ -47,10 +47,10 @@ exclude = [
 
 [project.optional-dependencies]
 opt = [
-  "altair",
+  "altair>=6.0.0,<7.0.0",
 ]
 dev = [
-  "altair",
+  "altair>=6.0.0,<7.0.0",
   "black",
   "flake8",
   "pytest",
@@ -67,7 +67,7 @@ doc = [
   "mkdocstrings-python"
 ]
 demo = [
-  "altair",
+  "altair>=6.0.0,<7.0.0",
   "pyaml",
   "pandas",
   "tornado",

--- a/chartlets.py/pyproject.toml
+++ b/chartlets.py/pyproject.toml
@@ -47,10 +47,10 @@ exclude = [
 
 [project.optional-dependencies]
 opt = [
-  "altair>=5.5.0,<6.0.0",
+  "altair",
 ]
 dev = [
-  "altair>=5.5.0,<6.0.0",
+  "altair",
   "black",
   "flake8",
   "pytest",
@@ -67,7 +67,7 @@ doc = [
   "mkdocstrings-python"
 ]
 demo = [
-  "altair>=5.5.0,<6.0.0",
+  "altair",
   "pyaml",
   "pandas",
   "tornado",

--- a/chartlets.py/tests/components/charts/vega_test.py
+++ b/chartlets.py/tests/components/charts/vega_test.py
@@ -36,7 +36,7 @@ class VegaChartTest(make_base(VegaChart)):
                 "id": "plot",
                 "theme": "dark",
                 "chart": {
-                    "$schema": "https://vega.github.io/schema/vega-lite/v5.20.1.json",
+                    "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
                     "config": {
                         "view": {"continuousHeight": 300, "continuousWidth": 300}
                     },


### PR DESCRIPTION
This PR:

- updates react-vega to v8 and adapts VegaChart accordingly (see [rect-vega migration guide](https://github.com/vega/react-vega?tab=readme-ov-file#migrating-to-v8))
- removes `altair` pinning. This is not necessary anymore
- integrates VegaChart component in testing (after beeing excluded in #131)

Closes #132.