### PR TITLE
Fix Progress component

### DIFF
--- a/chartlets.js/CHANGES.md
+++ b/chartlets.js/CHANGES.md
@@ -6,6 +6,11 @@
 	- `vite: ^8.0.16`
 	- `vitest: ^4.1.8`
 
+* Added `visible` support for progress components. Progress indicators can
+  now be hidden via `visible={false}` and are automatically shown while a
+  server-side callback with an output such as `Output("progress", "visible")`
+  is pending.
+  
 ## Version 0.2.0 (from 2026/03/11)
 
 * Updated dependencies

--- a/chartlets.js/CHANGES.md
+++ b/chartlets.js/CHANGES.md
@@ -7,7 +7,7 @@
 	- `vitest: ^4.1.8`
 
 * Added `hidden` support for progress components. Progress indicators can
-  now be hidden via `hidden={false}` and are automatically shown while a
+  now be hidden via `hidden={true}` and are automatically shown while a
   server-side callback with an output such as `Output("progress", "hidden")`
   is pending.
   

--- a/chartlets.js/CHANGES.md
+++ b/chartlets.js/CHANGES.md
@@ -8,8 +8,9 @@
 
 * Added `hidden` support for progress components. Progress indicators can
   now be hidden via `hidden={true}` and are automatically shown while a
-  server-side callback with an output such as `Output("progress", "hidden")`
-  is pending.
+  server-side callback with `Output("progress", "hidden")`
+  is pending. Examples: `docs/guide/contributors.md` and 
+  `chartlets.py/demo/my_extension/my_panel_10.py`. (#145)
   
 ## Version 0.2.0 (from 2026/03/11)
 

--- a/chartlets.js/CHANGES.md
+++ b/chartlets.js/CHANGES.md
@@ -6,9 +6,9 @@
 	- `vite: ^8.0.16`
 	- `vitest: ^4.1.8`
 
-* Added `visible` support for progress components. Progress indicators can
-  now be hidden via `visible={false}` and are automatically shown while a
-  server-side callback with an output such as `Output("progress", "visible")`
+* Added `hidden` support for progress components. Progress indicators can
+  now be hidden via `hidden={false}` and are automatically shown while a
+  server-side callback with an output such as `Output("progress", "hidden")`
   is pending.
   
 ## Version 0.2.0 (from 2026/03/11)

--- a/chartlets.js/DEV_NOTES.md
+++ b/chartlets.js/DEV_NOTES.md
@@ -66,8 +66,7 @@ spinner that is still needed by another pending callback.
 
 ## Alternative
 
-The alternative would be to let every panel manage long-running work with 
-background jobs, stored job state, or another user action to fetch the finished 
-result. That would keep the logic out of the frontend, but it would make each 
-panel more complicated to create and maintain for the contributors.
+The alternative would be to let every panel manage the state of long-running 
+callback requests. This would keep the logic out of the frontend, but it would 
+make each panel more complicated to set-up and maintain for the contributors.
 

--- a/chartlets.js/DEV_NOTES.md
+++ b/chartlets.js/DEV_NOTES.md
@@ -1,0 +1,73 @@
+# Progress Implementation Note
+
+Chartlets progress components are normal components, like all the others. 
+`CircularProgress` and `LinearProgress` render when `hidden` is false and 
+do not render when `hidden` is true.
+
+The extra progress logic (`chartlets.js/packages/lib/src/actions/helpers/pendingProgress.ts`)
+exists only to cover a timing problem: a backend callback can return 
+component state changes only after it has finished. Without some frontend 
+help, a Python callback computes for several seconds cannot show a spinner
+during that same callback.
+
+## How Pending Progress Works
+
+A panel configures a progress component in its layout:
+
+```python
+CircularProgress(id="loading_progress", hidden=True)
+```
+
+If a callback's output includes the progress component's `hidden` property,
+chartlets treats it as a pending-progress target:
+
+```python
+Output("loading_progress", "hidden")
+```
+
+When the callback is invoked, the frontend does the following before 
+sending the backend request:
+
+1. Find callback outputs that target `hidden` on a progress component.
+2. Set those targets to `hidden: false` locally.
+3. Send the backend callback request.
+
+When the backend response arrives, normal callback outputs are applied. The
+Python callback should return the final progress state, usually `True` for
+`hidden` so the spinner disappears.
+
+```python
+return True, result
+```
+
+## Why The Output Is Required
+
+The output declaration is the only signal that connects the callback to the
+progress component. If a panel removes this output:
+
+```python
+# Output("loading_progress", "hidden")
+```
+
+then the frontend does not know that this callback should show that spinner.
+The spinner remains in its layout state.
+
+## Failure Handling
+
+If the backend callback fails, no backend output will arrive to hide the
+spinner. In that case, the frontend hides completed pending-progress targets by
+setting `hidden: true`.
+
+## Overlapping Callbacks
+
+Multiple callbacks can target the same progress component. chartlets keeps a
+small pending count per progress target so one finished callback does not hide a
+spinner that is still needed by another pending callback.
+
+## Alternative
+
+The alternative would be to let every panel manage long-running work with 
+background jobs, stored job state, or another user action to fetch the finished 
+result. That would keep the logic out of the frontend, but it would make each 
+panel more complicated to create and maintain for the contributors.
+

--- a/chartlets.js/package-lock.json
+++ b/chartlets.js/package-lock.json
@@ -1487,14 +1487,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -1526,9 +1526,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.2.tgz",
-      "integrity": "sha512-2cZ+7xRS+DBcuJBJKnfzsbleumJhBqSlJVpuzHC0nTqfd3QQ7Vx2/x5YR/D7cBamKSeWplwo82Fn9lqYUDEMfA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
       "cpu": [
         "arm64"
       ],
@@ -1543,9 +1543,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.2.tgz",
-      "integrity": "sha512-RkPMJnygxsgOYdkfqgpwY0/Fzm8d0VQe6HGU2/B00Xa9eqdLbrII+DOKAodbJAn3ZL1AJxGHkZRPYazgGY6Ljw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
       "cpu": [
         "arm64"
       ],
@@ -1560,9 +1560,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.2.tgz",
-      "integrity": "sha512-Uiczh6vFhwyfd7WNe7Q7mCA4KxAiLdz7jPE/WGizfRpIieoyFuNVMmM8HqZ9HwudTkY6/AeMQwlNJ9NJijguWw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
       "cpu": [
         "x64"
       ],
@@ -1577,9 +1577,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.2.tgz",
-      "integrity": "sha512-+TpdtTRgHiJFjCVFbw311SuLk3KfytPOQQn+VlAEv+gBxYPtL7E6JS9e/tk+8CwxhIZvemJKo4rTKgfWNsKkkA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
       "cpu": [
         "x64"
       ],
@@ -1594,9 +1594,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.2.tgz",
-      "integrity": "sha512-4lv1/tkmi7ueIVHnyreaOeUpiZP26BH9rRy6hoYfR9310A2B9nUEVRDvBx69vx64Nr3eTPPRkyciqJJs+j9Jmw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
       "cpu": [
         "arm"
       ],
@@ -1611,9 +1611,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.2.tgz",
-      "integrity": "sha512-gBSUVO0eaWgw1JMjK3gB8BMlX2Mk148s2lTiVT3e9vjVxbl7UDfMWWY8CfIaaqiXuM9fVTMxIpUz6CAo/B6Vlw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
       "cpu": [
         "arm64"
       ],
@@ -1628,9 +1628,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.2.tgz",
-      "integrity": "sha512-LjQP/iZLBu8o8PjIfk4x3At0/mT6h282pvz8Z5LAyhGbu/kDezyO7ea62rF5uoqmgnIYqbN/MqJ3Si3Aymi7xQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
       "cpu": [
         "arm64"
       ],
@@ -1645,9 +1645,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.2.tgz",
-      "integrity": "sha512-X/7bVLWelEsbyWDUSXt7zVsTniLLPIY2n1rH58qr78l9i7MNbbxBWD8gI2vRfBWf4NUXJCUuQnfZDsp32LqsfQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
       "cpu": [
         "ppc64"
       ],
@@ -1662,9 +1662,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.2.tgz",
-      "integrity": "sha512-gb6dYKW/1KDorGXyy48glEBJs/sxVSC5pcVrox/pFGV4mvwSFeg2sK5L2tRkVsVlh7kueqOgg4GEcuipJcGuKg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
       "cpu": [
         "s390x"
       ],
@@ -1679,9 +1679,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.2.tgz",
-      "integrity": "sha512-JY4w85pU3iAiJVMh5nuk4/Mh9GjMsupe8MrIN53rwxAZW64GKrWeJBuN6SxQg9QTU5uB1cxyhDzW8jqRn1EABw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
       "cpu": [
         "x64"
       ],
@@ -1696,9 +1696,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.2.tgz",
-      "integrity": "sha512-xvpA7o5KCYLB0Rwscmuylb1/zHHSUx4g4xilm4prC5jP76pEUlzBmMbgpbh7bVDbId4NcfT96gN5i6mE6UDaiw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
       "cpu": [
         "x64"
       ],
@@ -1713,9 +1713,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.2.tgz",
-      "integrity": "sha512-p/ts6KBLjuk49Bp21XH77poQGt02iNz7ChgHep7tudPOaLinR/De/RHdxF8w8Yj4r/bF/bqXwH6PZrB2sA+Nvw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
       "cpu": [
         "arm64"
       ],
@@ -1730,9 +1730,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.2.tgz",
-      "integrity": "sha512-VMu/wmrZ9hJzYlRhbw7jK5PODlugyKZ5mOdX78+lS8OvuFkWNQdz1pFLrI2p3P0pjXOmUZ7B48o5VnMH9QOGtg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
       "cpu": [
         "wasm32"
       ],
@@ -1742,16 +1742,16 @@
       "dependencies": {
         "@emnapi/core": "1.11.1",
         "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.5"
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.2.tgz",
-      "integrity": "sha512-xtUJqs8qEkuSviS0n1tsohaPuz3a1SPhZywOji4Oo+sgrJs8daEDMZ0QtqL0OS7dx8PoVpg2J/ZZycPY5I2+Zg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
       "cpu": [
         "arm64"
       ],
@@ -1766,9 +1766,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.2.tgz",
-      "integrity": "sha512-85YiLQqjUKgSO/Zjnf9e0XIn5Ymrh1fLDWBeAkZqpuBR/3R8TpfoHXuyblqyQrftSSgWO9qpcHN8mkyKsLraoA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
       "cpu": [
         "x64"
       ],
@@ -2921,14 +2921,14 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.38.tgz",
-      "integrity": "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
+      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
-        "@vue/shared": "3.5.38",
+        "@vue/shared": "3.5.39",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
@@ -2948,14 +2948,14 @@
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.38.tgz",
-      "integrity": "sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
+      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.38",
-        "@vue/shared": "3.5.38"
+        "@vue/compiler-core": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/compiler-vue2": {
@@ -3021,9 +3021,9 @@
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
-      "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
+      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3210,9 +3210,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3890,9 +3890,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.377",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.377.tgz",
-      "integrity": "sha512-cH1jZgJHoezfTnKfKwnScpHywTFVnJUNITDPREFdhNjiuD502+QFpG0Qk7G8jhsV/f+CEAFlIrzP1fT+IMb92g==",
+      "version": "1.5.379",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.379.tgz",
+      "integrity": "sha512-v/qV5aV5EUA2pGilzUCq5/eyOloZAqDZBu9UMBIzgPpLlprjSR6zswsWBTv0KpqxLGUAZEwhO95ZCt7srymNVA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4219,9 +4219,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5614,9 +5614,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.48",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
-      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6118,9 +6118,9 @@
       "license": "Unlicense"
     },
     "node_modules/rolldown": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.2.tgz",
-      "integrity": "sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6134,21 +6134,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.2",
-        "@rolldown/binding-darwin-arm64": "1.1.2",
-        "@rolldown/binding-darwin-x64": "1.1.2",
-        "@rolldown/binding-freebsd-x64": "1.1.2",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.2",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.2",
-        "@rolldown/binding-linux-arm64-musl": "1.1.2",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.2",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.2",
-        "@rolldown/binding-linux-x64-gnu": "1.1.2",
-        "@rolldown/binding-linux-x64-musl": "1.1.2",
-        "@rolldown/binding-openharmony-arm64": "1.1.2",
-        "@rolldown/binding-wasm32-wasi": "1.1.2",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.2",
-        "@rolldown/binding-win32-x64-msvc": "1.1.2"
+        "@rolldown/binding-android-arm64": "1.1.3",
+        "@rolldown/binding-darwin-arm64": "1.1.3",
+        "@rolldown/binding-darwin-x64": "1.1.3",
+        "@rolldown/binding-freebsd-x64": "1.1.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+        "@rolldown/binding-linux-arm64-musl": "1.1.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-musl": "1.1.3",
+        "@rolldown/binding-openharmony-arm64": "1.1.3",
+        "@rolldown/binding-wasm32-wasi": "1.1.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+        "@rolldown/binding-win32-x64-msvc": "1.1.3"
       }
     },
     "node_modules/rrweb-cssom": {

--- a/chartlets.js/packages/lib/src/actions/helpers/invokeCallbacks.test.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/invokeCallbacks.test.ts
@@ -7,8 +7,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { store } from "@/store";
+import type { CallbackRequest, StateChangeRequest } from "@/types/model/callback";
 import type { ComponentState } from "@/types/state/component";
-import type { StateChangeRequest } from "@/types/model/callback";
 import { invokeCallbacks } from "./invokeCallbacks";
 
 function createDeferred<T>() {
@@ -23,6 +23,14 @@ function getProgressComponent() {
   return (store.getState().contributionsRecord.panels[0].component!
     .children![0] as ComponentState);
 }
+
+const callbackRequest: CallbackRequest = {
+  contribPoint: "panels",
+  contribIndex: 0,
+  callbackIndex: 0,
+  inputIndex: 0,
+  inputValues: [true],
+};
 
 describe("invokeCallbacks", () => {
   beforeEach(() => {
@@ -66,38 +74,70 @@ describe("invokeCallbacks", () => {
     vi.restoreAllMocks();
   });
 
-  it("shows progress while a callback with a progress visibility output is pending", async () => {
+  it("shows pending progress and applies callback results", async () => {
     const deferred = createDeferred<Response>();
     globalThis.fetch = vi.fn().mockReturnValue(deferred.promise);
 
-    invokeCallbacks([
-      {
-        contribPoint: "panels",
-        contribIndex: 0,
-        callbackIndex: 0,
-        inputIndex: 0,
-        inputValues: [true],
-      },
-    ]);
+    invokeCallbacks([callbackRequest]);
 
     expect(getProgressComponent().visible).toBe(true);
 
-    const callbackResult: StateChangeRequest[] = [
+    deferred.resolve(createCallbackResponse([
       {
         contribPoint: "panels",
         contribIndex: 0,
         stateChanges: [{ id: "progress", property: "visible", value: false }],
       },
-    ];
-    deferred.resolve({
-      ok: true,
-      status: 200,
-      statusText: "ok",
-      json: vi.fn().mockResolvedValue({ result: callbackResult }),
-    } as unknown as Response);
+    ]));
 
     await vi.waitFor(() => {
       expect(getProgressComponent().visible).toBe(false);
     });
   });
+
+  it("logs and releases pending progress when a callback fails", async () => {
+    const deferred = createDeferred<Response>();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockReturnValue(deferred.promise);
+
+    invokeCallbacks([callbackRequest]);
+
+    expect(getProgressComponent().visible).toBe(true);
+
+    deferred.resolve({
+      ok: true,
+      status: 200,
+      statusText: "ok",
+      json: vi.fn().mockResolvedValue({ message: "unexpected" }),
+    } as unknown as Response);
+
+    await vi.waitFor(() => {
+      expect(getProgressComponent().visible).toBe(false);
+    });
+    expect(consoleError).toHaveBeenCalledOnce();
+  });
+
+  it("logs callback requests and results when logging is enabled", async () => {
+    const deferred = createDeferred<Response>();
+    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockReturnValue(deferred.promise);
+    store.setState({ configuration: { logging: { enabled: true } } });
+
+    invokeCallbacks([callbackRequest]);
+
+    deferred.resolve(createCallbackResponse([]));
+
+    await vi.waitFor(() => {
+      expect(consoleInfo).toHaveBeenCalledTimes(2);
+    });
+  });
 });
+
+function createCallbackResponse(result: StateChangeRequest[]) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "ok",
+    json: vi.fn().mockResolvedValue({ result }),
+  } as unknown as Response;
+}

--- a/chartlets.js/packages/lib/src/actions/helpers/invokeCallbacks.test.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/invokeCallbacks.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2019-2026 by Brockmann Consult Development team
+ * Permissions are hereby granted under the terms of the MIT License:
+ * https://opensource.org/licenses/MIT.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { store } from "@/store";
+import type { ComponentState } from "@/types/state/component";
+import type { StateChangeRequest } from "@/types/model/callback";
+import { invokeCallbacks } from "./invokeCallbacks";
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function getProgressComponent() {
+  return (store.getState().contributionsRecord.panels[0].component!
+    .children![0] as ComponentState);
+}
+
+describe("invokeCallbacks", () => {
+  beforeEach(() => {
+    store.setState({
+      configuration: {},
+      extensions: [{ name: "ext", version: "0", contributes: ["panels"] }],
+      contributionsResult: {},
+      contributionsRecord: {
+        panels: [
+          {
+            name: "panel",
+            extension: "ext",
+            container: {},
+            componentResult: { status: "ok" },
+            component: {
+              type: "Box",
+              children: [
+                {
+                  type: "CircularProgress",
+                  id: "progress",
+                  visible: false,
+                },
+              ],
+            },
+            callbacks: [
+              {
+                function: { name: "calculate", parameters: [], return: {} },
+                inputs: [{ id: "run", property: "clicked" }],
+                outputs: [{ id: "progress", property: "visible" }],
+              },
+            ],
+            initialState: {},
+          },
+        ],
+      },
+      lastCallbackInputValues: {},
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows progress while a callback with a progress visibility output is pending", async () => {
+    const deferred = createDeferred<Response>();
+    globalThis.fetch = vi.fn().mockReturnValue(deferred.promise);
+
+    invokeCallbacks([
+      {
+        contribPoint: "panels",
+        contribIndex: 0,
+        callbackIndex: 0,
+        inputIndex: 0,
+        inputValues: [true],
+      },
+    ]);
+
+    expect(getProgressComponent().visible).toBe(true);
+
+    const callbackResult: StateChangeRequest[] = [
+      {
+        contribPoint: "panels",
+        contribIndex: 0,
+        stateChanges: [{ id: "progress", property: "visible", value: false }],
+      },
+    ];
+    deferred.resolve({
+      ok: true,
+      status: 200,
+      statusText: "ok",
+      json: vi.fn().mockResolvedValue({ result: callbackResult }),
+    } as unknown as Response);
+
+    await vi.waitFor(() => {
+      expect(getProgressComponent().visible).toBe(false);
+    });
+  });
+});

--- a/chartlets.js/packages/lib/src/actions/helpers/invokeCallbacks.test.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/invokeCallbacks.test.ts
@@ -51,11 +51,7 @@ describe("invokeCallbacks", () => {
             component: {
               type: "Box",
               children: [
-                {
-                  type: "CircularProgress",
-                  id: "progress",
-                  hidden: true,
-                },
+                { type: "CircularProgress", id: "progress", hidden: true },
               ],
             },
             callbacks: [
@@ -77,12 +73,13 @@ describe("invokeCallbacks", () => {
     vi.restoreAllMocks();
   });
 
-  it("shows pending progress and applies callback results", async () => {
+  it("shows progress while the backend callback is pending", async () => {
     const deferred = createDeferred<Response>();
     globalThis.fetch = vi.fn().mockReturnValue(deferred.promise);
 
     invokeCallbacks([callbackRequest]);
 
+    // The spinner is shown before the backend response arrives.
     expect(getProgressComponent().hidden).toBe(false);
 
     deferred.resolve(
@@ -95,12 +92,13 @@ describe("invokeCallbacks", () => {
       ]),
     );
 
+    // On success, the backend result provides the final hidden state.
     await vi.waitFor(() => {
       expect(getProgressComponent().hidden).toBe(true);
     });
   });
 
-  it("logs and releases pending progress when a callback fails", async () => {
+  it("hides progress when the backend callback fails", async () => {
     const deferred = createDeferred<Response>();
     const consoleError = vi
       .spyOn(console, "error")
@@ -108,7 +106,6 @@ describe("invokeCallbacks", () => {
     globalThis.fetch = vi.fn().mockReturnValue(deferred.promise);
 
     invokeCallbacks([callbackRequest]);
-
     expect(getProgressComponent().hidden).toBe(false);
 
     deferred.resolve({
@@ -118,25 +115,11 @@ describe("invokeCallbacks", () => {
       json: vi.fn().mockResolvedValue({ message: "unexpected" }),
     } as unknown as Response);
 
+    // On failure, no backend output is applied, so the frontend hides the spinner.
     await vi.waitFor(() => {
       expect(getProgressComponent().hidden).toBe(true);
     });
     expect(consoleError).toHaveBeenCalledOnce();
-  });
-
-  it("logs callback requests and results when logging is enabled", async () => {
-    const deferred = createDeferred<Response>();
-    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => {});
-    globalThis.fetch = vi.fn().mockReturnValue(deferred.promise);
-    store.setState({ configuration: { logging: { enabled: true } } });
-
-    invokeCallbacks([callbackRequest]);
-
-    deferred.resolve(createCallbackResponse([]));
-
-    await vi.waitFor(() => {
-      expect(consoleInfo).toHaveBeenCalledTimes(2);
-    });
   });
 });
 

--- a/chartlets.js/packages/lib/src/actions/helpers/invokeCallbacks.test.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/invokeCallbacks.test.ts
@@ -7,7 +7,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { store } from "@/store";
-import type { CallbackRequest, StateChangeRequest } from "@/types/model/callback";
+import type {
+  CallbackRequest,
+  StateChangeRequest,
+} from "@/types/model/callback";
 import type { ComponentState } from "@/types/state/component";
 import { invokeCallbacks } from "./invokeCallbacks";
 
@@ -20,8 +23,8 @@ function createDeferred<T>() {
 }
 
 function getProgressComponent() {
-  return (store.getState().contributionsRecord.panels[0].component!
-    .children![0] as ComponentState);
+  return store.getState().contributionsRecord.panels[0].component!
+    .children![0] as ComponentState;
 }
 
 const callbackRequest: CallbackRequest = {
@@ -51,7 +54,7 @@ describe("invokeCallbacks", () => {
                 {
                   type: "CircularProgress",
                   id: "progress",
-                  visible: false,
+                  hidden: false,
                 },
               ],
             },
@@ -59,7 +62,7 @@ describe("invokeCallbacks", () => {
               {
                 function: { name: "calculate", parameters: [], return: {} },
                 inputs: [{ id: "run", property: "clicked" }],
-                outputs: [{ id: "progress", property: "visible" }],
+                outputs: [{ id: "progress", property: "hidden" }],
               },
             ],
             initialState: {},
@@ -80,29 +83,33 @@ describe("invokeCallbacks", () => {
 
     invokeCallbacks([callbackRequest]);
 
-    expect(getProgressComponent().visible).toBe(true);
+    expect(getProgressComponent().hidden).toBe(true);
 
-    deferred.resolve(createCallbackResponse([
-      {
-        contribPoint: "panels",
-        contribIndex: 0,
-        stateChanges: [{ id: "progress", property: "visible", value: false }],
-      },
-    ]));
+    deferred.resolve(
+      createCallbackResponse([
+        {
+          contribPoint: "panels",
+          contribIndex: 0,
+          stateChanges: [{ id: "progress", property: "hidden", value: false }],
+        },
+      ]),
+    );
 
     await vi.waitFor(() => {
-      expect(getProgressComponent().visible).toBe(false);
+      expect(getProgressComponent().hidden).toBe(false);
     });
   });
 
   it("logs and releases pending progress when a callback fails", async () => {
     const deferred = createDeferred<Response>();
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     globalThis.fetch = vi.fn().mockReturnValue(deferred.promise);
 
     invokeCallbacks([callbackRequest]);
 
-    expect(getProgressComponent().visible).toBe(true);
+    expect(getProgressComponent().hidden).toBe(true);
 
     deferred.resolve({
       ok: true,
@@ -112,7 +119,7 @@ describe("invokeCallbacks", () => {
     } as unknown as Response);
 
     await vi.waitFor(() => {
-      expect(getProgressComponent().visible).toBe(false);
+      expect(getProgressComponent().hidden).toBe(false);
     });
     expect(consoleError).toHaveBeenCalledOnce();
   });

--- a/chartlets.js/packages/lib/src/actions/helpers/invokeCallbacks.test.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/invokeCallbacks.test.ts
@@ -54,7 +54,7 @@ describe("invokeCallbacks", () => {
                 {
                   type: "CircularProgress",
                   id: "progress",
-                  hidden: false,
+                  hidden: true,
                 },
               ],
             },
@@ -83,20 +83,20 @@ describe("invokeCallbacks", () => {
 
     invokeCallbacks([callbackRequest]);
 
-    expect(getProgressComponent().hidden).toBe(true);
+    expect(getProgressComponent().hidden).toBe(false);
 
     deferred.resolve(
       createCallbackResponse([
         {
           contribPoint: "panels",
           contribIndex: 0,
-          stateChanges: [{ id: "progress", property: "hidden", value: false }],
+          stateChanges: [{ id: "progress", property: "hidden", value: true }],
         },
       ]),
     );
 
     await vi.waitFor(() => {
-      expect(getProgressComponent().hidden).toBe(false);
+      expect(getProgressComponent().hidden).toBe(true);
     });
   });
 
@@ -109,7 +109,7 @@ describe("invokeCallbacks", () => {
 
     invokeCallbacks([callbackRequest]);
 
-    expect(getProgressComponent().hidden).toBe(true);
+    expect(getProgressComponent().hidden).toBe(false);
 
     deferred.resolve({
       ok: true,
@@ -119,7 +119,7 @@ describe("invokeCallbacks", () => {
     } as unknown as Response);
 
     await vi.waitFor(() => {
-      expect(getProgressComponent().hidden).toBe(false);
+      expect(getProgressComponent().hidden).toBe(true);
     });
     expect(consoleError).toHaveBeenCalledOnce();
   });

--- a/chartlets.js/packages/lib/src/actions/helpers/invokeCallbacks.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/invokeCallbacks.ts
@@ -5,31 +5,14 @@
  */
 
 import { store } from "@/store";
-import type {
-  CallbackRequest,
-  StateChangeRequest,
-} from "@/types/model/callback";
-import type { Output } from "@/types/model/channel";
-import type { ComponentState } from "@/types/state/component";
+import type { CallbackRequest } from "@/types/model/callback";
 import { fetchCallback } from "@/api/fetchCallback";
 import { applyStateChangeRequests } from "@/actions/helpers/applyStateChangeRequests";
-import { formatObjPath } from "@/utils/objPath";
-
-interface PendingProgressTarget {
-  contribPoint: string;
-  contribIndex: number;
-  id: string;
-  output: Output;
-}
-
-const progressComponentTypes = new Set([
-  "CircularProgress",
-  "CircularProgressWithLabel",
-  "LinearProgress",
-  "LinearProgressWithLabel",
-]);
-
-const pendingProgressCounts: Record<string, number> = {};
+import {
+  getPendingProgressTargets,
+  releasePendingProgressTargets,
+  showPendingProgressTargets,
+} from "@/actions/helpers/pendingProgress";
 
 export function invokeCallbacks(callbackRequests: CallbackRequest[]) {
   const { configuration } = store.getState();
@@ -64,116 +47,6 @@ export function invokeCallbacks(callbackRequests: CallbackRequest[]) {
         releasePendingProgressTargets(pendingProgressTargets, false);
       }
     },
-  );
-}
-
-function getPendingProgressTargets(
-  callbackRequests: CallbackRequest[],
-): PendingProgressTarget[] {
-  const { contributionsRecord } = store.getState();
-  const targets: PendingProgressTarget[] = [];
-  const targetKeys = new Set<string>();
-
-  callbackRequests.forEach(({ contribPoint, contribIndex, callbackIndex }) => {
-    const contribution = contributionsRecord[contribPoint]?.[contribIndex];
-    const callback = contribution?.callbacks?.[callbackIndex];
-    callback?.outputs?.forEach((output) => {
-      if (
-        formatObjPath(output.property) === "visible" &&
-        isProgressComponent(contribution.component, output.id)
-      ) {
-        const target = { contribPoint, contribIndex, id: output.id, output };
-        const key = getPendingProgressTargetKey(target);
-        if (!targetKeys.has(key)) {
-          targetKeys.add(key);
-          targets.push(target);
-        }
-      }
-    });
-  });
-
-  return targets;
-}
-
-function showPendingProgressTargets(targets: PendingProgressTarget[]) {
-  incrementPendingProgressCounts(targets);
-  applyPendingProgressTargets(targets, true);
-}
-
-function releasePendingProgressTargets(
-  targets: PendingProgressTarget[],
-  callbackSucceeded: boolean,
-) {
-  decrementPendingProgressCounts(targets);
-  const stillPendingTargets = targets.filter(
-    (target) => pendingProgressCounts[getPendingProgressTargetKey(target)] > 0,
-  );
-  applyPendingProgressTargets(stillPendingTargets, true);
-
-  if (!callbackSucceeded) {
-    const completedTargets = targets.filter(
-      (target) => !pendingProgressCounts[getPendingProgressTargetKey(target)],
-    );
-    applyPendingProgressTargets(completedTargets, false);
-  }
-}
-
-function incrementPendingProgressCounts(targets: PendingProgressTarget[]) {
-  targets.forEach((target) => {
-    const key = getPendingProgressTargetKey(target);
-    pendingProgressCounts[key] = (pendingProgressCounts[key] || 0) + 1;
-  });
-}
-
-function decrementPendingProgressCounts(targets: PendingProgressTarget[]) {
-  targets.forEach((target) => {
-    const key = getPendingProgressTargetKey(target);
-    const count = (pendingProgressCounts[key] || 0) - 1;
-    if (count > 0) {
-      pendingProgressCounts[key] = count;
-    } else {
-      delete pendingProgressCounts[key];
-    }
-  });
-}
-
-function applyPendingProgressTargets(
-  targets: PendingProgressTarget[],
-  visible: boolean,
-) {
-  if (targets.length === 0) {
-    return;
-  }
-  applyStateChangeRequests(
-    targets.map<StateChangeRequest>((target) => ({
-      contribPoint: target.contribPoint,
-      contribIndex: target.contribIndex,
-      stateChanges: [{ ...target.output, value: visible }],
-    })),
-  );
-}
-
-function getPendingProgressTargetKey(target: PendingProgressTarget) {
-  return `${target.contribPoint}-${target.contribIndex}-${target.id}`;
-}
-
-function isProgressComponent(
-  component: ComponentState | undefined,
-  id: string,
-): boolean {
-  if (!component) {
-    return false;
-  }
-  if (component.id === id) {
-    return progressComponentTypes.has(component.type);
-  }
-  return Boolean(
-    component.children?.some(
-      (child) =>
-        typeof child === "object" &&
-        child !== null &&
-        isProgressComponent(child, id),
-    ),
   );
 }
 

--- a/chartlets.js/packages/lib/src/actions/helpers/invokeCallbacks.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/invokeCallbacks.ts
@@ -5,14 +5,38 @@
  */
 
 import { store } from "@/store";
-import type { CallbackRequest } from "@/types/model/callback";
+import type {
+  CallbackRequest,
+  StateChangeRequest,
+} from "@/types/model/callback";
+import type { Output } from "@/types/model/channel";
+import type { ComponentState } from "@/types/state/component";
 import { fetchCallback } from "@/api/fetchCallback";
 import { applyStateChangeRequests } from "@/actions/helpers/applyStateChangeRequests";
+import { formatObjPath } from "@/utils/objPath";
+
+interface PendingProgressTarget {
+  contribPoint: string;
+  contribIndex: number;
+  id: string;
+  output: Output;
+}
+
+const progressComponentTypes = new Set([
+  "CircularProgress",
+  "CircularProgressWithLabel",
+  "LinearProgress",
+  "LinearProgressWithLabel",
+]);
+
+const pendingProgressCounts: Record<string, number> = {};
 
 export function invokeCallbacks(callbackRequests: CallbackRequest[]) {
   const { configuration } = store.getState();
   const shouldLog = configuration.logging?.enabled;
   const invocationId = getInvocationId();
+  const pendingProgressTargets = getPendingProgressTargets(callbackRequests);
+  showPendingProgressTargets(pendingProgressTargets);
   if (shouldLog) {
     console.info(
       `chartlets: invokeCallbacks (${invocationId})-->`,
@@ -29,6 +53,7 @@ export function invokeCallbacks(callbackRequests: CallbackRequest[]) {
           );
         }
         applyStateChangeRequests(changeRequestsResult.data);
+        releasePendingProgressTargets(pendingProgressTargets, true);
       } else {
         console.error(
           "callback failed:",
@@ -36,8 +61,119 @@ export function invokeCallbacks(callbackRequests: CallbackRequest[]) {
           "for call requests:",
           callbackRequests,
         );
+        releasePendingProgressTargets(pendingProgressTargets, false);
       }
     },
+  );
+}
+
+function getPendingProgressTargets(
+  callbackRequests: CallbackRequest[],
+): PendingProgressTarget[] {
+  const { contributionsRecord } = store.getState();
+  const targets: PendingProgressTarget[] = [];
+  const targetKeys = new Set<string>();
+
+  callbackRequests.forEach(({ contribPoint, contribIndex, callbackIndex }) => {
+    const contribution = contributionsRecord[contribPoint]?.[contribIndex];
+    const callback = contribution?.callbacks?.[callbackIndex];
+    callback?.outputs?.forEach((output) => {
+      if (
+        formatObjPath(output.property) === "visible" &&
+        isProgressComponent(contribution.component, output.id)
+      ) {
+        const target = { contribPoint, contribIndex, id: output.id, output };
+        const key = getPendingProgressTargetKey(target);
+        if (!targetKeys.has(key)) {
+          targetKeys.add(key);
+          targets.push(target);
+        }
+      }
+    });
+  });
+
+  return targets;
+}
+
+function showPendingProgressTargets(targets: PendingProgressTarget[]) {
+  incrementPendingProgressCounts(targets);
+  applyPendingProgressTargets(targets, true);
+}
+
+function releasePendingProgressTargets(
+  targets: PendingProgressTarget[],
+  callbackSucceeded: boolean,
+) {
+  decrementPendingProgressCounts(targets);
+  const stillPendingTargets = targets.filter(
+    (target) => pendingProgressCounts[getPendingProgressTargetKey(target)] > 0,
+  );
+  applyPendingProgressTargets(stillPendingTargets, true);
+
+  if (!callbackSucceeded) {
+    const completedTargets = targets.filter(
+      (target) => !pendingProgressCounts[getPendingProgressTargetKey(target)],
+    );
+    applyPendingProgressTargets(completedTargets, false);
+  }
+}
+
+function incrementPendingProgressCounts(targets: PendingProgressTarget[]) {
+  targets.forEach((target) => {
+    const key = getPendingProgressTargetKey(target);
+    pendingProgressCounts[key] = (pendingProgressCounts[key] || 0) + 1;
+  });
+}
+
+function decrementPendingProgressCounts(targets: PendingProgressTarget[]) {
+  targets.forEach((target) => {
+    const key = getPendingProgressTargetKey(target);
+    const count = (pendingProgressCounts[key] || 0) - 1;
+    if (count > 0) {
+      pendingProgressCounts[key] = count;
+    } else {
+      delete pendingProgressCounts[key];
+    }
+  });
+}
+
+function applyPendingProgressTargets(
+  targets: PendingProgressTarget[],
+  visible: boolean,
+) {
+  if (targets.length === 0) {
+    return;
+  }
+  applyStateChangeRequests(
+    targets.map<StateChangeRequest>((target) => ({
+      contribPoint: target.contribPoint,
+      contribIndex: target.contribIndex,
+      stateChanges: [{ ...target.output, value: visible }],
+    })),
+  );
+}
+
+function getPendingProgressTargetKey(target: PendingProgressTarget) {
+  return `${target.contribPoint}-${target.contribIndex}-${target.id}`;
+}
+
+function isProgressComponent(
+  component: ComponentState | undefined,
+  id: string,
+): boolean {
+  if (!component) {
+    return false;
+  }
+  if (component.id === id) {
+    return progressComponentTypes.has(component.type);
+  }
+  return Boolean(
+    component.children?.some(
+      (child) =>
+        typeof child === "object" &&
+        child !== null &&
+        isProgressComponent(child, id),
+    ),
   );
 }
 

--- a/chartlets.js/packages/lib/src/actions/helpers/invokeCallbacks.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/invokeCallbacks.ts
@@ -14,6 +14,15 @@ import {
   showPendingProgressTargets,
 } from "@/actions/helpers/pendingProgress";
 
+/**
+ * Invokes backend callbacks and applies their returned state changes.
+ *
+ * Before the request is sent, progress components declared as callback outputs
+ * are shown so users get immediate feedback while the backend is still
+ * working. Once the request resolves, normal callback outputs are applied. On
+ * failed callbacks, pending progress targets are hidden because no backend
+ * output will arrive to restore their final state.
+ */
 export function invokeCallbacks(callbackRequests: CallbackRequest[]) {
   const { configuration } = store.getState();
   const shouldLog = configuration.logging?.enabled;

--- a/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.test.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.test.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2019-2026 by Brockmann Consult Development team
+ * Permissions are hereby granted under the terms of the MIT License:
+ * https://opensource.org/licenses/MIT.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { store } from "@/store";
+import type { CallbackRequest } from "@/types/model/callback";
+import type { ComponentState } from "@/types/state/component";
+import {
+  getPendingProgressTargets,
+  releasePendingProgressTargets,
+  showPendingProgressTargets,
+} from "./pendingProgress";
+
+const callbackRequest: CallbackRequest = {
+  contribPoint: "panels",
+  contribIndex: 0,
+  callbackIndex: 0,
+  inputIndex: 0,
+  inputValues: [true],
+};
+
+function getProgressComponent() {
+  return (store.getState().contributionsRecord.panels[0].component!
+    .children![0] as ComponentState);
+}
+
+describe("pendingProgress", () => {
+  beforeEach(() => {
+    store.setState({
+      configuration: {},
+      extensions: [{ name: "ext", version: "0", contributes: ["panels"] }],
+      contributionsResult: {},
+      contributionsRecord: {
+        panels: [
+          {
+            name: "panel",
+            extension: "ext",
+            container: {},
+            componentResult: { status: "ok" },
+            component: {
+              type: "Box",
+              children: [
+                {
+                  type: "CircularProgress",
+                  id: "progress",
+                  visible: false,
+                },
+                {
+                  type: "Typography",
+                  id: "text",
+                  visible: false,
+                },
+              ],
+            },
+            callbacks: [
+              {
+                function: { name: "calculate", parameters: [], return: {} },
+                inputs: [{ id: "run", property: "clicked" }],
+                outputs: [{ id: "progress", property: "visible" }],
+              },
+              {
+                function: { name: "duplicate", parameters: [], return: {} },
+                inputs: [{ id: "run", property: "clicked" }],
+                outputs: [
+                  { id: "progress", property: "visible" },
+                  { id: "progress", property: "visible" },
+                ],
+              },
+              {
+                function: { name: "text", parameters: [], return: {} },
+                inputs: [{ id: "run", property: "clicked" }],
+                outputs: [{ id: "text", property: "visible" }],
+              },
+              {
+                function: { name: "value", parameters: [], return: {} },
+                inputs: [{ id: "run", property: "clicked" }],
+                outputs: [{ id: "progress", property: "value" }],
+              },
+            ],
+            initialState: {},
+          },
+        ],
+      },
+      lastCallbackInputValues: {},
+    });
+  });
+
+  it("finds progress components targeted by visible callback outputs", () => {
+    expect(getPendingProgressTargets([callbackRequest])).toEqual([
+      {
+        contribPoint: "panels",
+        contribIndex: 0,
+        id: "progress",
+        output: { id: "progress", property: "visible" },
+      },
+    ]);
+  });
+
+  it("deduplicates repeated progress outputs from the same callback", () => {
+    const targets = getPendingProgressTargets([
+      { ...callbackRequest, callbackIndex: 1 },
+    ]);
+
+    expect(targets).toHaveLength(1);
+  });
+
+  it("ignores non-progress components and non-visible outputs", () => {
+    expect(
+      getPendingProgressTargets([{ ...callbackRequest, callbackIndex: 2 }]),
+    ).toEqual([]);
+    expect(
+      getPendingProgressTargets([{ ...callbackRequest, callbackIndex: 3 }]),
+    ).toEqual([]);
+  });
+
+  it("ignores progress outputs when no component tree has been loaded", () => {
+    store.setState({
+      contributionsRecord: {
+        panels: [
+          {
+            ...store.getState().contributionsRecord.panels[0],
+            component: undefined,
+          },
+        ],
+      },
+    });
+
+    expect(getPendingProgressTargets([callbackRequest])).toEqual([]);
+  });
+
+  it("shows and hides progress when a callback fails", () => {
+    const targets = getPendingProgressTargets([callbackRequest]);
+
+    showPendingProgressTargets(targets);
+
+    expect(getProgressComponent().visible).toBe(true);
+
+    releasePendingProgressTargets(targets, false);
+
+    expect(getProgressComponent().visible).toBe(false);
+  });
+
+  it("keeps progress visible until overlapping callbacks have completed", () => {
+    const targets = getPendingProgressTargets([callbackRequest]);
+
+    showPendingProgressTargets(targets);
+    showPendingProgressTargets(targets);
+
+    releasePendingProgressTargets(targets, true);
+
+    expect(getProgressComponent().visible).toBe(true);
+
+    releasePendingProgressTargets(targets, false);
+
+    expect(getProgressComponent().visible).toBe(false);
+  });
+});

--- a/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.test.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.test.ts
@@ -90,7 +90,7 @@ describe("pendingProgress", () => {
     releasePendingProgressTargets(targets, true);
     expect(getProgressComponent().hidden).toBe(false);
 
-    // A failed final callback has no backend result to hide the spinner, so JS does it.
+    // A failed final callback has no backend result to hide the spinner, so the frontend does it.
     releasePendingProgressTargets(targets, false);
     expect(getProgressComponent().hidden).toBe(true);
   });

--- a/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.test.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.test.ts
@@ -44,41 +44,20 @@ describe("pendingProgress", () => {
             component: {
               type: "Box",
               children: [
-                {
-                  type: "CircularProgress",
-                  id: "progress",
-                  hidden: true,
-                },
-                {
-                  type: "Typography",
-                  id: "text",
-                  hidden: true,
-                },
+                { type: "CircularProgress", id: "progress", hidden: true },
+                { type: "Typography", id: "text", hidden: true },
               ],
             },
             callbacks: [
               {
                 function: { name: "calculate", parameters: [], return: {} },
                 inputs: [{ id: "run", property: "clicked" }],
-                outputs: [{ id: "progress", property: "hidden" }],
-              },
-              {
-                function: { name: "duplicate", parameters: [], return: {} },
-                inputs: [{ id: "run", property: "clicked" }],
                 outputs: [
                   { id: "progress", property: "hidden" },
                   { id: "progress", property: "hidden" },
+                  { id: "text", property: "hidden" },
+                  { id: "progress", property: "value" },
                 ],
-              },
-              {
-                function: { name: "text", parameters: [], return: {} },
-                inputs: [{ id: "run", property: "clicked" }],
-                outputs: [{ id: "text", property: "hidden" }],
-              },
-              {
-                function: { name: "value", parameters: [], return: {} },
-                inputs: [{ id: "run", property: "clicked" }],
-                outputs: [{ id: "progress", property: "value" }],
               },
             ],
             initialState: {},
@@ -89,7 +68,9 @@ describe("pendingProgress", () => {
     });
   });
 
-  it("finds progress components targeted by hidden callback outputs", () => {
+  it("selects only hidden outputs that target progress components", () => {
+    // Only the progress component's hidden output should become a pending target.
+    // Duplicate outputs, non-progress components, and non-hidden outputs are ignored.
     expect(getPendingProgressTargets([callbackRequest])).toEqual([
       {
         contribPoint: "panels",
@@ -100,62 +81,17 @@ describe("pendingProgress", () => {
     ]);
   });
 
-  it("deduplicates repeated progress outputs from the same callback", () => {
-    const targets = getPendingProgressTargets([
-      { ...callbackRequest, callbackIndex: 1 },
-    ]);
-
-    expect(targets).toHaveLength(1);
-  });
-
-  it("ignores non-progress components and non-hidden outputs", () => {
-    expect(
-      getPendingProgressTargets([{ ...callbackRequest, callbackIndex: 2 }]),
-    ).toEqual([]);
-    expect(
-      getPendingProgressTargets([{ ...callbackRequest, callbackIndex: 3 }]),
-    ).toEqual([]);
-  });
-
-  it("ignores progress outputs when no component tree has been loaded", () => {
-    store.setState({
-      contributionsRecord: {
-        panels: [
-          {
-            ...store.getState().contributionsRecord.panels[0],
-            component: undefined,
-          },
-        ],
-      },
-    });
-
-    expect(getPendingProgressTargets([callbackRequest])).toEqual([]);
-  });
-
-  it("shows and hides progress when a callback fails", () => {
+  it("keeps progress visible until all overlapping callbacks are released", () => {
     const targets = getPendingProgressTargets([callbackRequest]);
 
-    showPendingProgressTargets(targets);
-
-    expect(getProgressComponent().hidden).toBe(false);
-
-    releasePendingProgressTargets(targets, false);
-
-    expect(getProgressComponent().hidden).toBe(true);
-  });
-
-  it("keeps progress visible until overlapping callbacks have completed", () => {
-    const targets = getPendingProgressTargets([callbackRequest]);
-
+    // Two overlapping callbacks should show the spinner once and keep it visible.
     showPendingProgressTargets(targets);
     showPendingProgressTargets(targets);
-
     releasePendingProgressTargets(targets, true);
-
     expect(getProgressComponent().hidden).toBe(false);
 
+    // A failed final callback has no backend result to hide the spinner, so JS does it.
     releasePendingProgressTargets(targets, false);
-
     expect(getProgressComponent().hidden).toBe(true);
   });
 });

--- a/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.test.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.test.ts
@@ -24,8 +24,8 @@ const callbackRequest: CallbackRequest = {
 };
 
 function getProgressComponent() {
-  return (store.getState().contributionsRecord.panels[0].component!
-    .children![0] as ComponentState);
+  return store.getState().contributionsRecord.panels[0].component!
+    .children![0] as ComponentState;
 }
 
 describe("pendingProgress", () => {
@@ -47,12 +47,12 @@ describe("pendingProgress", () => {
                 {
                   type: "CircularProgress",
                   id: "progress",
-                  visible: false,
+                  hidden: false,
                 },
                 {
                   type: "Typography",
                   id: "text",
-                  visible: false,
+                  hidden: false,
                 },
               ],
             },
@@ -60,20 +60,20 @@ describe("pendingProgress", () => {
               {
                 function: { name: "calculate", parameters: [], return: {} },
                 inputs: [{ id: "run", property: "clicked" }],
-                outputs: [{ id: "progress", property: "visible" }],
+                outputs: [{ id: "progress", property: "hidden" }],
               },
               {
                 function: { name: "duplicate", parameters: [], return: {} },
                 inputs: [{ id: "run", property: "clicked" }],
                 outputs: [
-                  { id: "progress", property: "visible" },
-                  { id: "progress", property: "visible" },
+                  { id: "progress", property: "hidden" },
+                  { id: "progress", property: "hidden" },
                 ],
               },
               {
                 function: { name: "text", parameters: [], return: {} },
                 inputs: [{ id: "run", property: "clicked" }],
-                outputs: [{ id: "text", property: "visible" }],
+                outputs: [{ id: "text", property: "hidden" }],
               },
               {
                 function: { name: "value", parameters: [], return: {} },
@@ -89,13 +89,13 @@ describe("pendingProgress", () => {
     });
   });
 
-  it("finds progress components targeted by visible callback outputs", () => {
+  it("finds progress components targeted by hidden callback outputs", () => {
     expect(getPendingProgressTargets([callbackRequest])).toEqual([
       {
         contribPoint: "panels",
         contribIndex: 0,
         id: "progress",
-        output: { id: "progress", property: "visible" },
+        output: { id: "progress", property: "hidden" },
       },
     ]);
   });
@@ -108,7 +108,7 @@ describe("pendingProgress", () => {
     expect(targets).toHaveLength(1);
   });
 
-  it("ignores non-progress components and non-visible outputs", () => {
+  it("ignores non-progress components and non-hidden outputs", () => {
     expect(
       getPendingProgressTargets([{ ...callbackRequest, callbackIndex: 2 }]),
     ).toEqual([]);
@@ -137,14 +137,14 @@ describe("pendingProgress", () => {
 
     showPendingProgressTargets(targets);
 
-    expect(getProgressComponent().visible).toBe(true);
+    expect(getProgressComponent().hidden).toBe(true);
 
     releasePendingProgressTargets(targets, false);
 
-    expect(getProgressComponent().visible).toBe(false);
+    expect(getProgressComponent().hidden).toBe(false);
   });
 
-  it("keeps progress visible until overlapping callbacks have completed", () => {
+  it("keeps progress hidden until overlapping callbacks have completed", () => {
     const targets = getPendingProgressTargets([callbackRequest]);
 
     showPendingProgressTargets(targets);
@@ -152,10 +152,10 @@ describe("pendingProgress", () => {
 
     releasePendingProgressTargets(targets, true);
 
-    expect(getProgressComponent().visible).toBe(true);
+    expect(getProgressComponent().hidden).toBe(true);
 
     releasePendingProgressTargets(targets, false);
 
-    expect(getProgressComponent().visible).toBe(false);
+    expect(getProgressComponent().hidden).toBe(false);
   });
 });

--- a/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.test.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.test.ts
@@ -47,12 +47,12 @@ describe("pendingProgress", () => {
                 {
                   type: "CircularProgress",
                   id: "progress",
-                  hidden: false,
+                  hidden: true,
                 },
                 {
                   type: "Typography",
                   id: "text",
-                  hidden: false,
+                  hidden: true,
                 },
               ],
             },
@@ -137,14 +137,14 @@ describe("pendingProgress", () => {
 
     showPendingProgressTargets(targets);
 
-    expect(getProgressComponent().hidden).toBe(true);
+    expect(getProgressComponent().hidden).toBe(false);
 
     releasePendingProgressTargets(targets, false);
 
-    expect(getProgressComponent().hidden).toBe(false);
+    expect(getProgressComponent().hidden).toBe(true);
   });
 
-  it("keeps progress hidden until overlapping callbacks have completed", () => {
+  it("keeps progress visible until overlapping callbacks have completed", () => {
     const targets = getPendingProgressTargets([callbackRequest]);
 
     showPendingProgressTargets(targets);
@@ -152,10 +152,10 @@ describe("pendingProgress", () => {
 
     releasePendingProgressTargets(targets, true);
 
-    expect(getProgressComponent().hidden).toBe(true);
+    expect(getProgressComponent().hidden).toBe(false);
 
     releasePendingProgressTargets(targets, false);
 
-    expect(getProgressComponent().hidden).toBe(false);
+    expect(getProgressComponent().hidden).toBe(true);
   });
 });

--- a/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2019-2026 by Brockmann Consult Development team
+ * Permissions are hereby granted under the terms of the MIT License:
+ * https://opensource.org/licenses/MIT.
+ */
+
+import { store } from "@/store";
+import type { CallbackRequest, StateChangeRequest } from "@/types/model/callback";
+import type { Output } from "@/types/model/channel";
+import type { ComponentState } from "@/types/state/component";
+import { applyStateChangeRequests } from "@/actions/helpers/applyStateChangeRequests";
+import { formatObjPath } from "@/utils/objPath";
+
+export interface PendingProgressTarget {
+  contribPoint: string;
+  contribIndex: number;
+  id: string;
+  output: Output;
+}
+
+const progressComponentTypes = new Set([
+  "CircularProgress",
+  "CircularProgressWithLabel",
+  "LinearProgress",
+  "LinearProgressWithLabel",
+]);
+
+const pendingProgressCounts: Record<string, number> = {};
+
+export function getPendingProgressTargets(
+  callbackRequests: CallbackRequest[],
+): PendingProgressTarget[] {
+  const { contributionsRecord } = store.getState();
+  const targets: PendingProgressTarget[] = [];
+  const targetKeys = new Set<string>();
+
+  callbackRequests.forEach(({ contribPoint, contribIndex, callbackIndex }) => {
+    const contribution = contributionsRecord[contribPoint]?.[contribIndex];
+    const callback = contribution?.callbacks?.[callbackIndex];
+    callback?.outputs?.forEach((output) => {
+      if (
+        formatObjPath(output.property) === "visible" &&
+        isProgressComponent(contribution.component, output.id)
+      ) {
+        const target = { contribPoint, contribIndex, id: output.id, output };
+        const key = getPendingProgressTargetKey(target);
+        if (!targetKeys.has(key)) {
+          targetKeys.add(key);
+          targets.push(target);
+        }
+      }
+    });
+  });
+
+  return targets;
+}
+
+export function showPendingProgressTargets(targets: PendingProgressTarget[]) {
+  incrementPendingProgressCounts(targets);
+  applyPendingProgressTargets(targets, true);
+}
+
+export function releasePendingProgressTargets(
+  targets: PendingProgressTarget[],
+  callbackSucceeded: boolean,
+) {
+  decrementPendingProgressCounts(targets);
+  const stillPendingTargets = targets.filter(
+    (target) => pendingProgressCounts[getPendingProgressTargetKey(target)] > 0,
+  );
+  applyPendingProgressTargets(stillPendingTargets, true);
+
+  if (!callbackSucceeded) {
+    const completedTargets = targets.filter(
+      (target) => !pendingProgressCounts[getPendingProgressTargetKey(target)],
+    );
+    applyPendingProgressTargets(completedTargets, false);
+  }
+}
+
+function incrementPendingProgressCounts(targets: PendingProgressTarget[]) {
+  targets.forEach((target) => {
+    const key = getPendingProgressTargetKey(target);
+    pendingProgressCounts[key] = (pendingProgressCounts[key] || 0) + 1;
+  });
+}
+
+function decrementPendingProgressCounts(targets: PendingProgressTarget[]) {
+  targets.forEach((target) => {
+    const key = getPendingProgressTargetKey(target);
+    const count = (pendingProgressCounts[key] || 0) - 1;
+    if (count > 0) {
+      pendingProgressCounts[key] = count;
+    } else {
+      delete pendingProgressCounts[key];
+    }
+  });
+}
+
+function applyPendingProgressTargets(
+  targets: PendingProgressTarget[],
+  visible: boolean,
+) {
+  if (targets.length === 0) {
+    return;
+  }
+  applyStateChangeRequests(
+    targets.map<StateChangeRequest>((target) => ({
+      contribPoint: target.contribPoint,
+      contribIndex: target.contribIndex,
+      stateChanges: [{ ...target.output, value: visible }],
+    })),
+  );
+}
+
+function getPendingProgressTargetKey(target: PendingProgressTarget) {
+  return `${target.contribPoint}-${target.contribIndex}-${target.id}`;
+}
+
+function isProgressComponent(
+  component: ComponentState | undefined,
+  id: string,
+): boolean {
+  if (!component) {
+    return false;
+  }
+  if (component.id === id) {
+    return progressComponentTypes.has(component.type);
+  }
+  return Boolean(
+    component.children?.some(
+      (child) =>
+        typeof child === "object" &&
+        child !== null &&
+        isProgressComponent(child, id),
+    ),
+  );
+}

--- a/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.ts
@@ -14,6 +14,13 @@ import type { ComponentState } from "@/types/state/component";
 import { applyStateChangeRequests } from "@/actions/helpers/applyStateChangeRequests";
 import { formatObjPath } from "@/utils/objPath";
 
+/**
+ * A progress component output that should be shown while a callback is pending.
+ *
+ * The output is always a component `hidden` output. While the backend callback is
+ * running, chartlets applies `hidden: false` locally. The backend callback result
+ * is still responsible for the final state after it returns.
+ */
 export interface PendingProgressTarget {
   contribPoint: string;
   contribIndex: number;
@@ -30,6 +37,14 @@ const progressComponentTypes = new Set([
 
 const pendingProgressCounts: Record<string, number> = {};
 
+/**
+ * Finds callback outputs that target the `hidden` property of progress
+ * components in the currently rendered contribution tree.
+ *
+ * This is the bridge between a Python callback declaring
+ * `Output("some_progress", "hidden")` and the frontend showing that progress
+ * component before the callback response arrives.
+ */
 export function getPendingProgressTargets(
   callbackRequests: CallbackRequest[],
 ): PendingProgressTarget[] {
@@ -58,11 +73,22 @@ export function getPendingProgressTargets(
   return targets;
 }
 
+/**
+ * Shows pending progress targets immediately by setting `hidden` to `false`.
+ */
 export function showPendingProgressTargets(targets: PendingProgressTarget[]) {
   incrementPendingProgressCounts(targets);
   applyPendingProgressTargets(targets, false);
 }
 
+/**
+ * Releases progress targets after a callback finishes.
+ *
+ * Successful callbacks are expected to provide the final progress state in their
+ * own returned outputs. Failed callbacks do not have such outputs, so completed
+ * progress targets are hidden here. Overlapping callbacks keep the progress
+ * visible until the last pending callback has finished.
+ */
 export function releasePendingProgressTargets(
   targets: PendingProgressTarget[],
   callbackSucceeded: boolean,

--- a/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.ts
@@ -39,7 +39,7 @@ export function getPendingProgressTargets(
     const callback = contribution?.callbacks?.[callbackIndex];
     callback?.outputs?.forEach((output) => {
       if (
-        formatObjPath(output.property) === "visible" &&
+        formatObjPath(output.property) === "hidden" &&
         isProgressComponent(contribution.component, output.id)
       ) {
         const target = { contribPoint, contribIndex, id: output.id, output };
@@ -99,7 +99,7 @@ function decrementPendingProgressCounts(targets: PendingProgressTarget[]) {
 
 function applyPendingProgressTargets(
   targets: PendingProgressTarget[],
-  visible: boolean,
+  hidden: boolean,
 ) {
   if (targets.length === 0) {
     return;
@@ -108,7 +108,7 @@ function applyPendingProgressTargets(
     targets.map<StateChangeRequest>((target) => ({
       contribPoint: target.contribPoint,
       contribIndex: target.contribIndex,
-      stateChanges: [{ ...target.output, value: visible }],
+      stateChanges: [{ ...target.output, value: hidden }],
     })),
   );
 }

--- a/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.ts
+++ b/chartlets.js/packages/lib/src/actions/helpers/pendingProgress.ts
@@ -5,7 +5,10 @@
  */
 
 import { store } from "@/store";
-import type { CallbackRequest, StateChangeRequest } from "@/types/model/callback";
+import type {
+  CallbackRequest,
+  StateChangeRequest,
+} from "@/types/model/callback";
 import type { Output } from "@/types/model/channel";
 import type { ComponentState } from "@/types/state/component";
 import { applyStateChangeRequests } from "@/actions/helpers/applyStateChangeRequests";
@@ -57,7 +60,7 @@ export function getPendingProgressTargets(
 
 export function showPendingProgressTargets(targets: PendingProgressTarget[]) {
   incrementPendingProgressCounts(targets);
-  applyPendingProgressTargets(targets, true);
+  applyPendingProgressTargets(targets, false);
 }
 
 export function releasePendingProgressTargets(
@@ -68,13 +71,13 @@ export function releasePendingProgressTargets(
   const stillPendingTargets = targets.filter(
     (target) => pendingProgressCounts[getPendingProgressTargetKey(target)] > 0,
   );
-  applyPendingProgressTargets(stillPendingTargets, true);
+  applyPendingProgressTargets(stillPendingTargets, false);
 
   if (!callbackSucceeded) {
     const completedTargets = targets.filter(
       (target) => !pendingProgressCounts[getPendingProgressTargetKey(target)],
     );
-    applyPendingProgressTargets(completedTargets, false);
+    applyPendingProgressTargets(completedTargets, true);
   }
 }
 

--- a/chartlets.js/packages/lib/src/plugins/mui/CircularProgress.test.tsx
+++ b/chartlets.js/packages/lib/src/plugins/mui/CircularProgress.test.tsx
@@ -22,4 +22,17 @@ describe("CircularProgress", () => {
     // expect(document.querySelector("#cp")).toEqual({});
     expect(screen.getByRole("progressbar")).not.toBeUndefined();
   });
+
+  it("should not render when visible is false", () => {
+    render(
+      <CircularProgress
+        type="CircularProgress"
+        id="cp"
+        visible={false}
+        onChange={() => {}}
+      />,
+    );
+
+    expect(screen.queryByRole("progressbar")).toBeNull();
+  });
 });

--- a/chartlets.js/packages/lib/src/plugins/mui/CircularProgress.test.tsx
+++ b/chartlets.js/packages/lib/src/plugins/mui/CircularProgress.test.tsx
@@ -23,12 +23,12 @@ describe("CircularProgress", () => {
     expect(screen.getByRole("progressbar")).not.toBeUndefined();
   });
 
-  it("should not render when hidden is false", () => {
+  it("should not render when hidden is true", () => {
     render(
       <CircularProgress
         type="CircularProgress"
         id="cp"
-        hidden={false}
+        hidden={true}
         onChange={() => {}}
       />,
     );

--- a/chartlets.js/packages/lib/src/plugins/mui/CircularProgress.test.tsx
+++ b/chartlets.js/packages/lib/src/plugins/mui/CircularProgress.test.tsx
@@ -23,7 +23,7 @@ describe("CircularProgress", () => {
     expect(screen.getByRole("progressbar")).not.toBeUndefined();
   });
 
-  it("should not render when hidden is true", () => {
+  it("should not render when hidden", () => {
     render(
       <CircularProgress
         type="CircularProgress"

--- a/chartlets.js/packages/lib/src/plugins/mui/CircularProgress.test.tsx
+++ b/chartlets.js/packages/lib/src/plugins/mui/CircularProgress.test.tsx
@@ -23,12 +23,12 @@ describe("CircularProgress", () => {
     expect(screen.getByRole("progressbar")).not.toBeUndefined();
   });
 
-  it("should not render when visible is false", () => {
+  it("should not render when hidden is false", () => {
     render(
       <CircularProgress
         type="CircularProgress"
         id="cp"
-        visible={false}
+        hidden={false}
         onChange={() => {}}
       />,
     );

--- a/chartlets.js/packages/lib/src/plugins/mui/CircularProgress.tsx
+++ b/chartlets.js/packages/lib/src/plugins/mui/CircularProgress.tsx
@@ -22,7 +22,12 @@ export const CircularProgress = ({
   size,
   value,
   variant,
+  visible = true,
 }: CircularProgressProps) => {
+  if (!visible) {
+    return null;
+  }
+
   return (
     <MuiCircularProgress
       id={id}

--- a/chartlets.js/packages/lib/src/plugins/mui/CircularProgress.tsx
+++ b/chartlets.js/packages/lib/src/plugins/mui/CircularProgress.tsx
@@ -22,9 +22,9 @@ export const CircularProgress = ({
   size,
   value,
   variant,
-  hidden = true,
+  hidden = false,
 }: CircularProgressProps) => {
-  if (!hidden) {
+  if (hidden) {
     return null;
   }
 

--- a/chartlets.js/packages/lib/src/plugins/mui/CircularProgress.tsx
+++ b/chartlets.js/packages/lib/src/plugins/mui/CircularProgress.tsx
@@ -22,9 +22,9 @@ export const CircularProgress = ({
   size,
   value,
   variant,
-  visible = true,
+  hidden = true,
 }: CircularProgressProps) => {
-  if (!visible) {
+  if (!hidden) {
     return null;
   }
 

--- a/chartlets.js/packages/lib/src/plugins/mui/LinearProgress.test.tsx
+++ b/chartlets.js/packages/lib/src/plugins/mui/LinearProgress.test.tsx
@@ -22,4 +22,17 @@ describe("LinearProgress", () => {
     // expect(document.querySelector("#cp")).toEqual({});
     expect(screen.getByRole("progressbar")).not.toBeUndefined();
   });
+
+  it("should not render when visible is false", () => {
+    render(
+      <LinearProgress
+        type="LinearProgress"
+        id="cp"
+        visible={false}
+        onChange={() => {}}
+      />,
+    );
+
+    expect(screen.queryByRole("progressbar")).toBeNull();
+  });
 });

--- a/chartlets.js/packages/lib/src/plugins/mui/LinearProgress.test.tsx
+++ b/chartlets.js/packages/lib/src/plugins/mui/LinearProgress.test.tsx
@@ -23,7 +23,7 @@ describe("LinearProgress", () => {
     expect(screen.getByRole("progressbar")).not.toBeUndefined();
   });
 
-  it("should not render when hidden is true", () => {
+  it("should not render when hidden", () => {
     render(
       <LinearProgress
         type="LinearProgress"

--- a/chartlets.js/packages/lib/src/plugins/mui/LinearProgress.test.tsx
+++ b/chartlets.js/packages/lib/src/plugins/mui/LinearProgress.test.tsx
@@ -23,12 +23,12 @@ describe("LinearProgress", () => {
     expect(screen.getByRole("progressbar")).not.toBeUndefined();
   });
 
-  it("should not render when hidden is false", () => {
+  it("should not render when hidden is true", () => {
     render(
       <LinearProgress
         type="LinearProgress"
         id="cp"
-        hidden={false}
+        hidden={true}
         onChange={() => {}}
       />,
     );

--- a/chartlets.js/packages/lib/src/plugins/mui/LinearProgress.test.tsx
+++ b/chartlets.js/packages/lib/src/plugins/mui/LinearProgress.test.tsx
@@ -23,12 +23,12 @@ describe("LinearProgress", () => {
     expect(screen.getByRole("progressbar")).not.toBeUndefined();
   });
 
-  it("should not render when visible is false", () => {
+  it("should not render when hidden is false", () => {
     render(
       <LinearProgress
         type="LinearProgress"
         id="cp"
-        visible={false}
+        hidden={false}
         onChange={() => {}}
       />,
     );

--- a/chartlets.js/packages/lib/src/plugins/mui/LinearProgress.tsx
+++ b/chartlets.js/packages/lib/src/plugins/mui/LinearProgress.tsx
@@ -21,7 +21,12 @@ export const LinearProgress = ({
   style,
   value,
   variant,
+  visible = true,
 }: LinearProgressProps) => {
+  if (!visible) {
+    return null;
+  }
+
   return (
     <MuiLinearProgress id={id} style={style} value={value} variant={variant} />
   );

--- a/chartlets.js/packages/lib/src/plugins/mui/LinearProgress.tsx
+++ b/chartlets.js/packages/lib/src/plugins/mui/LinearProgress.tsx
@@ -21,9 +21,9 @@ export const LinearProgress = ({
   style,
   value,
   variant,
-  hidden = true,
+  hidden = false,
 }: LinearProgressProps) => {
-  if (!hidden) {
+  if (hidden) {
     return null;
   }
 

--- a/chartlets.js/packages/lib/src/plugins/mui/LinearProgress.tsx
+++ b/chartlets.js/packages/lib/src/plugins/mui/LinearProgress.tsx
@@ -21,9 +21,9 @@ export const LinearProgress = ({
   style,
   value,
   variant,
-  visible = true,
+  hidden = true,
 }: LinearProgressProps) => {
-  if (!visible) {
+  if (!hidden) {
     return null;
   }
 

--- a/chartlets.js/packages/lib/src/types/state/component.ts
+++ b/chartlets.js/packages/lib/src/types/state/component.ts
@@ -30,6 +30,7 @@ export interface ComponentState {
   label?: string;
   color?: string;
   tooltip?: string;
+  visible?: boolean;
 }
 
 export interface ContainerState extends ComponentState {

--- a/chartlets.js/packages/lib/src/types/state/component.ts
+++ b/chartlets.js/packages/lib/src/types/state/component.ts
@@ -30,7 +30,7 @@ export interface ComponentState {
   label?: string;
   color?: string;
   tooltip?: string;
-  visible?: boolean;
+  hidden?: boolean;
 }
 
 export interface ContainerState extends ComponentState {

--- a/chartlets.py/CHANGES.md
+++ b/chartlets.py/CHANGES.md
@@ -1,5 +1,9 @@
 ## Version 0.2.1 (in development)
 
+* Added `visible` property to the base `Component` class, so components can
+  be shown or hidden through callback outputs such as
+  `Output("progress", "visible")`.
+  
 ## Version 0.2.0 (from 2026/03/11)
 
 * Added `size` and removed `variant` property from `IconButton`

--- a/chartlets.py/CHANGES.md
+++ b/chartlets.py/CHANGES.md
@@ -1,8 +1,8 @@
 ## Version 0.2.1 (in development)
 
-* Added `visible` property to the base `Component` class, so components can
+* Added `hidden` property to the base `Component` class, so components can
   be shown or hidden through callback outputs such as
-  `Output("progress", "visible")`.
+  `Output("progress", "hidden")`.
   
 ## Version 0.2.0 (from 2026/03/11)
 

--- a/chartlets.py/chartlets/component.py
+++ b/chartlets.py/chartlets/component.py
@@ -38,6 +38,9 @@ class Component(ABC):
     color: str | None = None
     """HTML `color` attribute. Optional."""
 
+    visible: bool | None = None
+    """If set, controls whether the component is visible."""
+
     children: list[Union["Component", str, None]] | None = None
     """Children used by many specific components. Optional."""
 

--- a/chartlets.py/chartlets/component.py
+++ b/chartlets.py/chartlets/component.py
@@ -38,8 +38,8 @@ class Component(ABC):
     color: str | None = None
     """HTML `color` attribute. Optional."""
 
-    visible: bool | None = None
-    """If set, controls whether the component is visible."""
+    hidden: bool | None = None
+    """If set, controls whether the component is hidden."""
 
     children: list[Union["Component", str, None]] | None = None
     """Children used by many specific components. Optional."""

--- a/chartlets.py/demo/my_extension/__init__.py
+++ b/chartlets.py/demo/my_extension/__init__.py
@@ -12,6 +12,7 @@ from .my_panel_6 import panel as my_panel_6
 from .my_panel_7 import panel as my_panel_7
 from .my_panel_8 import panel as my_panel_8
 from .my_panel_9 import panel as my_panel_9
+from .my_panel_10 import panel as my_panel_10
 
 
 ext = Extension(__name__)
@@ -24,3 +25,4 @@ ext.add(my_panel_6)
 ext.add(my_panel_7)
 ext.add(my_panel_8)
 ext.add(my_panel_9)
+ext.add(my_panel_10)

--- a/chartlets.py/demo/my_extension/my_panel_10.py
+++ b/chartlets.py/demo/my_extension/my_panel_10.py
@@ -1,0 +1,73 @@
+#  Copyright (c) 2019-2026 by Brockmann Consult Development team
+#  Permissions are hereby granted under the terms of the MIT License:
+#  https://opensource.org/licenses/MIT.
+
+import time
+
+from chartlets import Component, Input, Output, State
+from chartlets.components import (
+    Box,
+    Button,
+    CircularProgress,
+    CircularProgressWithLabel,
+    LinearProgress,
+    Typography,
+)
+
+from server.context import Context
+from server.panel import Panel
+
+panel = Panel(__name__, title="Panel J")
+
+
+# noinspection PyUnusedLocal
+@panel.layout()
+def render_panel(ctx: Context) -> Component:
+    button = Button(
+        id="start_button",
+        text="wait for 3 seconds",
+        color="primary",
+        variant="contained",
+        style={"width": "fit-content"},
+    )
+    progress = CircularProgress(
+        id="loading_progress",
+        visible=False,
+        size=32,
+        style={"margin": "16px 0"},
+    )
+    result_text = Typography(
+        id="result_text",
+        text="",
+        variant="body1",
+    )
+
+    return Box(
+        style={
+            "display": "flex",
+            "flexDirection": "column",
+            "alignItems": "flex-start",
+            "gap": "8px",
+            "padding": "16px",
+        },
+        children=[button, progress, result_text],
+    )
+
+
+# noinspection PyUnusedLocal
+@panel.callback(
+    Input("start_button", "clicked"),
+    State("start_button", "text"),
+    Output("loading_progress", "visible"),
+    Output("result_text", "text"),
+    Output("start_button", "text"),
+    Output("start_button", "color"),
+)
+def run_calculation(
+    ctx: Context, clicked: bool, button_text: str
+) -> tuple[bool, str, str, str]:
+    if button_text == "reset":
+        return False, "", "wait for 3 seconds", "primary"
+
+    time.sleep(3)
+    return False, "Finished waiting after 3 seconds.", "reset", "inherit"

--- a/chartlets.py/demo/my_extension/my_panel_10.py
+++ b/chartlets.py/demo/my_extension/my_panel_10.py
@@ -32,7 +32,7 @@ def render_panel(ctx: Context) -> Component:
     )
     progress = CircularProgress(
         id="loading_progress",
-        hidden=False,
+        hidden=True,
         size=32,
         style={"margin": "16px 0"},
     )
@@ -58,7 +58,7 @@ def render_panel(ctx: Context) -> Component:
 @panel.callback(
     Input("start_button", "clicked"),
     State("start_button", "text"),
-    Output("loading_progress", "visible"),
+    Output("loading_progress", "hidden"),
     Output("result_text", "text"),
     Output("start_button", "text"),
     Output("start_button", "color"),
@@ -67,7 +67,8 @@ def run_calculation(
     ctx: Context, clicked: bool, button_text: str
 ) -> tuple[bool, str, str, str]:
     if button_text == "reset":
-        return False, "", "wait for 3 seconds", "primary"
+        return True, "", "wait for 3 seconds", "primary"
 
     time.sleep(3)
-    return False, "Finished waiting after 3 seconds.", "reset", "inherit"
+    return True, "Finished waiting after 3 seconds.", "reset", "inherit"
+

--- a/chartlets.py/demo/my_extension/my_panel_10.py
+++ b/chartlets.py/demo/my_extension/my_panel_10.py
@@ -32,7 +32,7 @@ def render_panel(ctx: Context) -> Component:
     )
     progress = CircularProgress(
         id="loading_progress",
-        visible=False,
+        hidden=False,
         size=32,
         style={"margin": "16px 0"},
     )

--- a/chartlets.py/tests/components/charts/vega_test.py
+++ b/chartlets.py/tests/components/charts/vega_test.py
@@ -35,27 +35,7 @@ class VegaChartTest(make_base(VegaChart)):
                 "type": "VegaChart",
                 "id": "plot",
                 "theme": "dark",
-                "chart": {
-                    "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
-                    "config": {
-                        "view": {"continuousHeight": 300, "continuousWidth": 300}
-                    },
-                    "data": {"name": "data-2780b27b376c14369bf3f449cf25f092"},
-                    "datasets": {
-                        "data-2780b27b376c14369bf3f449cf25f092": [
-                            {"a": 28, "x": "A"},
-                            {"a": 55, "x": "B"},
-                            {"a": 43, "x": "C"},
-                            {"a": 91, "x": "D"},
-                            {"a": 81, "x": "E"},
-                        ]
-                    },
-                    "encoding": {
-                        "x": {"field": "x", "title": "x", "type": "nominal"},
-                        "y": {"field": "a", "title": "a", "type": "quantitative"},
-                    },
-                    "mark": {"type": "bar"},
-                },
+                "chart": self.chart.to_dict(),
             },
         )
 

--- a/chartlets.py/tests/components/progress_test.py
+++ b/chartlets.py/tests/components/progress_test.py
@@ -13,8 +13,13 @@ class CircularProgressTest(make_base(CircularProgress)):
 
     def test_is_json_serializable(self):
         self.assert_is_json_serializable(
-            self.cls(color="success", value=10),
-            {"type": "CircularProgress", "color": "success", "value": 10},
+            self.cls(color="success", value=10, visible=False),
+            {
+                "type": "CircularProgress",
+                "color": "success",
+                "value": 10,
+                "visible": False,
+            },
         )
 
 

--- a/chartlets.py/tests/components/progress_test.py
+++ b/chartlets.py/tests/components/progress_test.py
@@ -27,8 +27,13 @@ class CircularProgressWithLabelTest(make_base(CircularProgressWithLabel)):
 
     def test_is_json_serializable(self):
         self.assert_is_json_serializable(
-            self.cls(color="primary", value=12),
-            {"type": "CircularProgressWithLabel", "color": "primary", "value": 12},
+            self.cls(color="primary", value=12, visible=False),
+            {
+                "type": "CircularProgressWithLabel",
+                "color": "primary",
+                "value": 12,
+                "visible": False,
+            },
         )
 
 
@@ -36,8 +41,13 @@ class LinearProgressTest(make_base(LinearProgress)):
 
     def test_is_json_serializable(self):
         self.assert_is_json_serializable(
-            self.cls(color="success", value=40),
-            {"type": "LinearProgress", "color": "success", "value": 40},
+            self.cls(color="success", value=40, visible=False),
+            {
+                "type": "LinearProgress",
+                "color": "success",
+                "value": 40,
+                "visible": False,
+            },
         )
 
 
@@ -45,6 +55,11 @@ class LinearProgressWithLabelTest(make_base(LinearProgressWithLabel)):
 
     def test_is_json_serializable(self):
         self.assert_is_json_serializable(
-            self.cls(color="secondary", value=42),
-            {"type": "LinearProgressWithLabel", "color": "secondary", "value": 42},
+            self.cls(color="secondary", value=42, visible=False),
+            {
+                "type": "LinearProgressWithLabel",
+                "color": "secondary",
+                "value": 42,
+                "visible": False,
+            },
         )

--- a/chartlets.py/tests/components/progress_test.py
+++ b/chartlets.py/tests/components/progress_test.py
@@ -13,12 +13,11 @@ class CircularProgressTest(make_base(CircularProgress)):
 
     def test_is_json_serializable(self):
         self.assert_is_json_serializable(
-            self.cls(color="success", value=10, visible=False),
+            self.cls(color="success", value=10),
             {
                 "type": "CircularProgress",
                 "color": "success",
                 "value": 10,
-                "visible": False,
             },
         )
 
@@ -27,12 +26,11 @@ class CircularProgressWithLabelTest(make_base(CircularProgressWithLabel)):
 
     def test_is_json_serializable(self):
         self.assert_is_json_serializable(
-            self.cls(color="primary", value=12, visible=False),
+            self.cls(color="primary", value=12),
             {
                 "type": "CircularProgressWithLabel",
                 "color": "primary",
                 "value": 12,
-                "visible": False,
             },
         )
 
@@ -41,12 +39,11 @@ class LinearProgressTest(make_base(LinearProgress)):
 
     def test_is_json_serializable(self):
         self.assert_is_json_serializable(
-            self.cls(color="success", value=40, visible=False),
+            self.cls(color="success", value=40),
             {
                 "type": "LinearProgress",
                 "color": "success",
                 "value": 40,
-                "visible": False,
             },
         )
 
@@ -55,11 +52,10 @@ class LinearProgressWithLabelTest(make_base(LinearProgressWithLabel)):
 
     def test_is_json_serializable(self):
         self.assert_is_json_serializable(
-            self.cls(color="secondary", value=42, visible=False),
+            self.cls(color="secondary", value=42),
             {
                 "type": "LinearProgressWithLabel",
                 "color": "secondary",
                 "value": 42,
-                "visible": False,
             },
         )

--- a/docs/guide/contributors.md
+++ b/docs/guide/contributors.md
@@ -84,3 +84,42 @@ from .stats_panel import panel as stats_panel
 ext = Extension("my_dashboard")
 ext.add(stats_panel)
 ```
+
+## How to report progress for long-lasting processes
+
+For callbacks that may take a noticeable amount of time, add a progress
+component to the layout and declare its `hidden` property as one of the
+callback outputs.
+
+```python
+from chartlets import Input, Output
+from chartlets.components import Box, Button, CircularProgress, Typography
+
+@panel.layout()
+def get_layout(ctx):
+    return Box(
+        children=[
+            Button(id="run_button", text="Run calculation"),
+            CircularProgress(id="loading_progress", hidden=True),
+            Typography(id="result_text", text=""),
+        ]
+    )
+
+@panel.callback(
+    Input("run_button", "clicked"),
+    Output("loading_progress", "hidden"),
+    Output("result_text", "text"),
+)
+def run_calculation(ctx, clicked):
+    result = do_long_running_work()
+    return True, result
+```
+
+The progress component starts hidden. When the callback is invoked, chartlets
+sees that the callback outputs to `loading_progress.hidden` and shows the
+progress component while the backend request is pending. When the callback
+returns, the first return value is applied to `hidden`; returning `True` hides
+the progress component again.
+
+The progress output must remain part of the callback outputs. If it is removed,
+chartlets cannot know that this callback should show the progress component.


### PR DESCRIPTION
**Description**

This PR fixes the behaviour of progress components by adding `hidden` support for the components and connecting it to callback execution state.

Progress components can now be hidden with `hidden=True` and shown via callback outputs such as:

```python
Output("progress", "hidden")
```

When a server-side callback declares a progress component’s `hidden` property as an output, chartlets now shows that progress indicator immediately while the callback request is pending. Once the callback completes, the normal callback output is applied, typically hiding the progress component again.

**Changes**

- Added `visible` to the shared component state model.
- Added pending-callback progress handling in `invokeCallbacks()`.
- Added a `DEV_NOTES.md` to explain the Progress logic.
- Added another demo panel, demonstrating the progress component.
- Other changes: 
  - Fixed `vega_test.py`.

**Demo Panel**

<img height="300" alt="image" src="https://github.com/user-attachments/assets/2a21d8fe-4c24-416c-9771-682cf8d696d8" />

**xcube-viewer panels demo**
<img width="1678" height="709" alt="grafik" src="https://github.com/user-attachments/assets/aa7986a5-cab5-4a6a-b463-8685ae69881a" />

